### PR TITLE
[FOGL-4721]: Added option for north as a service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,7 +38,7 @@ import {
   ServicesApiService,
   SupportService,
   SystemLogService,
-  UserService,
+  UserService
 } from './services';
 import { HttpsRequestInterceptor } from './services/http.request.interceptor';
 import { SharedService } from './services/shared.service';

--- a/src/app/components/common/alert-dialog/alert-dialog.component.ts
+++ b/src/app/components/common/alert-dialog/alert-dialog.component.ts
@@ -68,9 +68,7 @@ export class AlertDialogComponent implements OnInit, OnChanges {
       }
     }
     if (this.deleteTaskData) {
-      if (this.deleteTaskData.key === 'deleteTask') {
-        this.deleteTaskData.headerTextValue = 'Delete Instance';
-      }
+      this.deleteTaskData.headerTextValue = this.deleteTaskData.key === 'deleteTask' ? 'Delete Instance' : 'Delete Service';
     }
     if (this.notificationRecord) {
       if (this.notificationRecord.key === 'deleteNotification') {
@@ -164,7 +162,7 @@ export class AlertDialogComponent implements OnInit, OnChanges {
       }
     }
     if (this.deleteTaskData) {
-      if (this.deleteTaskData.key === 'deleteTask') {
+      if (this.deleteTaskData.key === 'deleteTask' || this.deleteTaskData.key === 'deleteService') {
         this.deleteTask.emit({
           name: this.deleteTaskData.name
         });

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.css
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.css
@@ -5,3 +5,7 @@
 .container.is-fluid {
   margin-top: 10px;
 }
+
+.service-checkbox {
+  padding-top: 0.4rem;
+}

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.css
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.css
@@ -7,5 +7,5 @@
 }
 
 .service-checkbox {
-  padding-top: 0.4rem;
+  padding-top: 0.25rem;
 }

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
@@ -90,6 +90,18 @@
           </div>
           <div *ngIf="plugins.length > 0" class="field is-horizontal form-group">
             <div class="field-label is-normal">
+              <label class="label">Add as a Service</label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="control service-checkbox">
+                  <input class="checkbox" type="checkbox" (click)="onServiceCheckboxClicked($event)">
+                </div>
+              </div>
+            </div>
+          </div>
+          <div *ngIf="plugins.length > 0 && isService === false" class="field is-horizontal form-group">
+            <div class="field-label is-normal">
               <label class="label">Repeat (Interval)</label>
             </div>
             <div class="field-body">

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.ts
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.ts
@@ -182,7 +182,7 @@ export class AddTaskWizardComponent implements OnInit, OnDestroy {
           return formValues['name'].trim() === item.name;
         });
         if (isTaskNameExist) {
-          this.alertService.error('A north task instance or south service already exists with this name.');
+          this.alertService.error('A service/task already exists with this name.');
           return false;
         }
 
@@ -209,10 +209,10 @@ export class AddTaskWizardComponent implements OnInit, OnDestroy {
         break;
       case 3:
         if (this.isService) {
-          this.payload.schedule_repeat = '';
-          this.payload.schedule_type = '1';
-          this.payload.enabled = this.isScheduleEnabled;
+          delete this.payload.schedule_repeat;
+          delete this.payload.schedule_type;
           delete this.payload.schedule_enabled;
+          this.payload.enabled = this.isScheduleEnabled;
           this.addService(this.payload);
         } else {
           this.addScheduledTask(this.payload);
@@ -331,10 +331,10 @@ export class AddTaskWizardComponent implements OnInit, OnDestroy {
     this.ngProgress.start();
     this.servicesApiService.addService(payload)
       .subscribe(
-        () => {
+        (response) => {
           /** request done */
           this.ngProgress.done();
-          this.alertService.success('Service added successfully.', true);
+          this.alertService.success(response['name'] + ' service added successfully.', true);
           this.router.navigate(['/north']);
         },
         (error) => {
@@ -424,20 +424,12 @@ export class AddTaskWizardComponent implements OnInit, OnDestroy {
   }
 
   onCheckboxClicked(event) {
-    if (event.target.checked) {
-      this.isScheduleEnabled = true;
-    } else {
-      this.isScheduleEnabled = false;
-    }
+    this.isScheduleEnabled = event.target.checked ? true : false;
     this.payload.schedule_enabled = this.isScheduleEnabled;
   }
 
   onServiceCheckboxClicked(event) {
-    if (event.target.checked) {
-      this.isService = true;
-    } else {
-      this.isService = false;
-    }
+    this.isService = event.target.checked ? true : false;
   }
 
   public getSchedules(): void {

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -2,7 +2,8 @@
   <div class="modal-background"></div>
   <div class="modal-card">
     <header class="modal-card-head" style="flex-grow:0;">
-      <p *ngIf="task != undefined" class="modal-card-title is-size-5">{{task.name}}</p>
+      <p *ngIf="task != undefined" class="modal-card-title is-size-5">{{task.name}}
+      <span *ngIf="task?.processName === 'north_C'" class="tag is-white is-rounded">Service</span></p>
       <button class="delete" aria-label="close" (click)="toggleModal(false)"></button>
     </header>
     <section class="modal-card-body">
@@ -33,7 +34,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="field is-horizontal">
+                <div *ngIf="task?.processName !== 'north_C'" class="field is-horizontal">
                   <div class="field-label has-text-left">
                     <label class="label">Exclusive</label>
                   </div>
@@ -44,7 +45,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="field is-horizontal">
+                <div *ngIf="task?.processName !== 'north_C'" class="field is-horizontal">
                   <div class="field-label has-text-left">
                     <label class="label">Interval</label>
                   </div>
@@ -124,8 +125,8 @@
           <div class="field">
             <div class="field has-text-right">
               <button *ngIf="task != undefined"
-                (click)="openDeleteModal(task.name,'Deleting this instance can not be undone. Continue?', 'deleteTask')"
-                class="button is-small">Delete Instance</button>
+                (click)="openDeleteModal(task.name, 'Deleting this ' + btnTxt + ' can not be undone. Continue?')"
+                class="button is-small">Delete {{btnTxt}}</button>
             </div>
           </div>
         </div>
@@ -137,7 +138,7 @@
       </ng-container>
     </section>
   </div>
-  <app-alert-dialog (deleteTask)='deleteTask($event)' [deleteTaskData]='deleteTaskData'></app-alert-dialog>
+  <app-alert-dialog (deleteTask)='onDelete($event)' [deleteTaskData]='deleteTaskData'></app-alert-dialog>
   <app-filter-alert *ngIf="isFilterOrderChanged || isFilterDeleted" (discardChanges)="discardChanges()"
     [filerDialogData]='confirmationDialogData'></app-filter-alert>
 </div>

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -34,7 +34,8 @@
                     </div>
                   </div>
                 </div>
-                <div *ngIf="task?.processName !== 'north_C'" class="field is-horizontal">
+                <ng-container *ngIf="task?.processName !== 'north_C'">
+                <div  class="field is-horizontal">
                   <div class="field-label has-text-left">
                     <label class="label">Exclusive</label>
                   </div>
@@ -45,7 +46,7 @@
                     </div>
                   </div>
                 </div>
-                <div *ngIf="task?.processName !== 'north_C'" class="field is-horizontal">
+                <div class="field is-horizontal">
                   <div class="field-label has-text-left">
                     <label class="label">Interval</label>
                   </div>
@@ -64,6 +65,7 @@
                     </div>
                   </div>
                 </div>
+              </ng-container>
               </div>
             </div>
             <button id="ss" class="is-hidden button is-small is-link is-pulled-right" form="taskForm">Save</button>

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.ts
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.ts
@@ -251,12 +251,17 @@ export class NorthTaskModalComponent implements OnInit, OnChanges {
       this.toggleModal(false);
       return false;
     }
-    const repeatInterval = form.controls['repeatTime'].value !== ('None' || undefined) ? Utils.convertTimeToSec(
-      form.controls['repeatTime'].value, form.controls['repeatDays'].value) : 0;
+    let repeatInterval;
+    let exclusiveValue;
+    if (this.task['processName'] !== 'north_C') {
+      repeatInterval = form.controls['repeatTime'].value !== ('None' || undefined) ? Utils.convertTimeToSec(
+        form.controls['repeatTime'].value, form.controls['repeatDays'].value) : 0;
+      exclusiveValue = form.controls['exclusive'].value;
+    }
     const updatePayload = {
       'repeat': repeatInterval,
-      'exclusive': form.controls['exclusive'].value,
-      'enabled': form.controls['enabled'].value
+      'enabled': form.controls['enabled'].value,
+      'exclusive': exclusiveValue
     };
     /** request started */
     this.ngProgress.start();

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.ts
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.ts
@@ -256,8 +256,10 @@ export class NorthTaskModalComponent implements OnInit, OnChanges {
     };
 
     if (this.task['processName'] !== 'north_C') {
-      updatePayload.repeat = form.controls['repeatTime'].value !== ('None' || undefined) ? Utils.convertTimeToSec(
-        form.controls['repeatTime'].value, form.controls['repeatDays'].value) : 0;
+      updatePayload.repeat = 0;
+      if(form.controls['repeatTime'].value !== ('None' || undefined)) {
+        updatePayload.repeat = Utils.convertTimeToSec(form.controls['repeatTime'].value, form.controls['repeatDays'].value);
+      }
       updatePayload.exclusive = form.controls['exclusive'].value;  
     }
     

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.ts
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.ts
@@ -251,18 +251,16 @@ export class NorthTaskModalComponent implements OnInit, OnChanges {
       this.toggleModal(false);
       return false;
     }
-    let repeatInterval;
-    let exclusiveValue;
-    if (this.task['processName'] !== 'north_C') {
-      repeatInterval = form.controls['repeatTime'].value !== ('None' || undefined) ? Utils.convertTimeToSec(
-        form.controls['repeatTime'].value, form.controls['repeatDays'].value) : 0;
-      exclusiveValue = form.controls['exclusive'].value;
-    }
-    const updatePayload = {
-      'repeat': repeatInterval,
-      'enabled': form.controls['enabled'].value,
-      'exclusive': exclusiveValue
+    const updatePayload: any = {
+      'enabled': form.controls['enabled'].value
     };
+
+    if (this.task['processName'] !== 'north_C') {
+      updatePayload.repeat = form.controls['repeatTime'].value !== ('None' || undefined) ? Utils.convertTimeToSec(
+        form.controls['repeatTime'].value, form.controls['repeatDays'].value) : 0;
+      updatePayload.exclusive = form.controls['exclusive'].value;  
+    }
+    
     /** request started */
     this.ngProgress.start();
     this.schedulesService.updateSchedule(this.task['id'], updatePayload).

--- a/src/app/components/core/north/north.component.html
+++ b/src/app/components/core/north/north.component.html
@@ -5,7 +5,7 @@
         North Instances
       </div>
       <a id="add_task" class="fix-pad button is-light" (click)="addNorthInstance()">
-        <p *ngIf="viewPort !== 'mobile'">Create North Instance &nbsp;</p>
+        <p *ngIf="viewPort !== 'mobile'">Add &nbsp;</p>
         <i class="fa fa-sm fa-plus" aria-hidden="true"></i>
       </a>
     </header>

--- a/src/app/components/core/north/north.component.html
+++ b/src/app/components/core/north/north.component.html
@@ -25,7 +25,7 @@
             <table class="table is-fullwidth scroll is-responsive is-hoverable">
               <thead>
                 <tr>
-                  <th>Process</th>
+                  <th>Name</th>
                   <th>Status</th>
                   <th>Plugin</th>
                   <th>Version</th>

--- a/src/app/components/core/north/north.component.html
+++ b/src/app/components/core/north/north.component.html
@@ -26,6 +26,7 @@
               <thead>
                 <tr>
                   <th>Name</th>
+                  <th></th>
                   <th>Status</th>
                   <th>Plugin</th>
                   <th>Version</th>
@@ -36,6 +37,9 @@
                 <tr *ngFor="let t of tasks" [ngClass]="{'fade': !t.enabled}">
                   <td class="align-content">
                     <a class="button is-text" (click)="openNorthTaskModal(t)">{{t.name}}</a>
+                  </td>
+                  <td class="align-content">
+                    <span *ngIf="t?.processName === 'north_C'" class="tag is-light is-rounded">Service</span>
                   </td>
                   <td>
                     <span *ngIf="t.enabled == true" class="tag is-success">enabled</span>

--- a/src/app/components/core/scheduler/list-schedules/list-schedules.component.ts
+++ b/src/app/components/core/scheduler/list-schedules/list-schedules.component.ts
@@ -105,8 +105,9 @@ export class ListSchedulesComponent implements OnInit {
         (data: any) => {
           /** request completed */
           this.ngProgress.done();
+          // north_c - North C tasks, north_C - Northbound C Services
           data.schedules.forEach(sch => {
-            if (!['south_c', 'north_c', 'south', 'north', 'notification_c'].includes(sch.processName)) {
+            if (!['south_c', 'north_c', 'north_C', 'south', 'north', 'notification_c'].includes(sch.processName)) {
               this.scheduleData.push(sch);
             }
           });

--- a/src/app/components/core/south/add-service-wizard/add-service-wizard.component.ts
+++ b/src/app/components/core/south/add-service-wizard/add-service-wizard.component.ts
@@ -282,18 +282,16 @@ export class AddServiceWizardComponent implements OnInit, OnDestroy {
   /**
    * Method to add service
    * @param payload  to pass in request
-   * @param nxtButton button to go next
-   * @param previousButton button to go previous
    */
   public addService(payload) {
     /** request started */
     this.ngProgress.start();
     this.servicesApiService.addService(payload)
       .subscribe(
-        () => {
+        (response) => {
           /** request done */
           this.ngProgress.done();
-          this.alertService.success('Service added successfully.', true);
+          this.alertService.success(response['name'] + ' service added successfully.', true);
           this.router.navigate(['/south']);
         },
         (error) => {

--- a/src/app/components/core/south/add-service-wizard/add-service-wizard.component.ts
+++ b/src/app/components/core/south/add-service-wizard/add-service-wizard.component.ts
@@ -170,7 +170,7 @@ export class AddServiceWizardComponent implements OnInit, OnDestroy {
           return formValues['name'].trim() === item.name;
         });
         if (isServiceNameExist) {
-          this.alertService.error('A south service or north task instance already exists with this name.');
+          this.alertService.error('A service/task already exists with this name.');
           return false;
         }
 


### PR DESCRIPTION
**TODO:**

- [x] Don't show repeat, day and exclusive fields on the detail page,  if it was added as a Service
- [x] Delete Instance should be Delete Service, if it was added as a Service,  same should reflect in confirmation alert; also verify corresponding calls
- [x] On list and details page (show  a tag for <span class="tag is-rounded">Service</span>)
- [ ] Sort by name and group by Services and Enabled
- [x] Fix message `A south service or north task instance already exists with this name.` for South. 
       - `A service/task already exists with this name.`

<img width="1275" alt="Screenshot 2020-12-09 at 1 23 36 PM" src="https://user-images.githubusercontent.com/29797330/101601317-918a6f80-3a22-11eb-9c28-9afa764a6ebe.png">

<img width="1278" alt="Screenshot 2020-12-09 at 1 25 10 PM" src="https://user-images.githubusercontent.com/29797330/101601333-95b68d00-3a22-11eb-88b4-5ce464ded6a9.png">

<img width="1277" alt="Screenshot 2020-12-09 at 1 28 44 PM" src="https://user-images.githubusercontent.com/29797330/101601356-9bac6e00-3a22-11eb-8f4d-89e72d911567.png">
