### PR TITLE
FOGL-4999: removed lowercase from plugin name to fix help documentation link breaks On south/north/filter/delivery/rule wizard for some plugins

### DIFF
--- a/src/app/services/doc.service.ts
+++ b/src/app/services/doc.service.ts
@@ -13,7 +13,7 @@ export class DocService {
 
   goToPluginLink(pluginInfo: any) {
     const v = version.includes('next') ? 'develop' : `v${version}`;
-    const p = `fledge-${pluginInfo.type.toLowerCase()}-${pluginInfo.name.toLowerCase()}`;
+    const p = `fledge-${pluginInfo.type.toLowerCase()}-${pluginInfo.name}`;
     window.open(`${doc_url}${v}/plugins/${p}/index.html`, '_blank');
   }
 


### PR DESCRIPTION
Signed-off-by: Mohd. Shariq <mohd.shariq@nerdapplabs.com>
