### PR TITLE
FOGL-5534 Allow paste into password fields

### DIFF
--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -45,7 +45,7 @@
                       <div class="control">
                         <input #pwd
                           name="{{configItem.value.key}}" class="input is-fullwidth is-small" type="password"
-                          onPaste="return false" [ngModel]="setConfigValue(configItem.value)"
+                          [ngModel]="setConfigValue(configItem.value)"
                           [attr.maxLength]="configItem?.value?.length" placeholder="password"
                           [required]="configItem?.value?.hasOwnProperty('mandatory') && configItem?.value?.mandatory=='true'"
                           (ngModelChange)="checkPasswords(pwd.value, f?.controls['confirm-password']?.value, configItem.value.key)"
@@ -66,7 +66,7 @@
                         <div id="confirm-password" class="field has-addons">
                           <div class="control">
                             <input #confirmPwd name="confirm-password" class="input is-fullwidth is-small"
-                              onPaste="return false" type="password" [ngModel]="setConfigValue(confirmPwd.value)"
+                              type="password" [ngModel]="setConfigValue(confirmPwd.value)"
                               [value]='setConfigValue(confirmPwd.value)' [attr.maxLength]="configItem?.value?.length"
                               placeholder="confirm password"
                               [hidden]="configItem?.value?.hasOwnProperty('editable') && !configItem?.value?.editable"


### PR DESCRIPTION
Signed-off-by: Mark Riddoch <mark@dianomic.com>

Allow paste into the password type fields as these are often used for complex access token/keys from remote systems and it is error prone to have to retype them manually.