### PR TITLE
FOGL:5900: Filtering on logs difficult with large number of services

### DIFF
--- a/src/app/components/core/system-log/system-log.component.css
+++ b/src/app/components/core/system-log/system-log.component.css
@@ -26,3 +26,10 @@
 #card-title {
   padding: 0.75rem 1.5rem;
 }
+
+.auto-refresh {
+  margin-top: 33px;
+  font-size: .75rem;
+  color: #363636;
+  font-weight: 700;
+}

--- a/src/app/components/core/system-log/system-log.component.html
+++ b/src/app/components/core/system-log/system-log.component.html
@@ -72,7 +72,17 @@
           </div>
           <div class="column">
             <label class="label is-small">Search</label>
-            <input type="search" class="input is-fullwidth is-small" placeholder="search text on current page" [(ngModel)]="searchTerm" />
+            <input type="search" class="input is-fullwidth is-small" placeholder="search text on current page"
+              [(ngModel)]="searchTerm" />
+          </div>
+          <div class="column is-2">
+            <div class="auto-refresh">
+              <label class="checkbox">
+                <input type="checkbox" [checked]='isAlive'
+                (click)="toggleAutoRefresh($event)">
+                Auto Refresh
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -90,7 +100,8 @@
     </ng-container>
     <ng-template #no_data_div>
       <div class="card-content">
-        <div class="has-text-centered"><small class="text-secondary has-text-grey-light">No Matching Log Entry Found</small></div>
+        <div class="has-text-centered"><small class="text-secondary has-text-grey-light">No Matching Log Entry
+            Found</small></div>
       </div>
     </ng-template>
   </div>

--- a/src/app/components/core/system-log/system-log.component.ts
+++ b/src/app/components/core/system-log/system-log.component.ts
@@ -257,6 +257,20 @@ export class SystemLogComponent implements OnInit, OnDestroy {
         });
   }
 
+  toggleAutoRefresh(event:any) {
+    this.isAlive = event.target.checked;
+    if(this.isAlive) {
+      interval(this.refreshInterval)
+      .pipe(takeWhile(() => this.isAlive), takeUntil(this.destroy$)) // only fires when component is alive
+      .subscribe(() => {
+        this.getSysLogs(true);
+        this.getSchedules();
+      });
+    }
+
+
+  }
+
   public ngOnDestroy(): void {
     this.isAlive = false;
     this.destroy$.next(true);


### PR DESCRIPTION
On System Logs page we have auto refresh functionality that refresh the data loaded in the page based on pingInterval. That causes issues with search functionality. So added option to start/stop auto refresh on system logs page 