### PR TITLE
FOGL-7489: Able to edit disabled codemirror field issue fixed

### DIFF
--- a/src/app/components/core/configuration-manager/show-configuration/show-configuration.component.ts
+++ b/src/app/components/core/configuration-manager/show-configuration/show-configuration.component.ts
@@ -72,6 +72,7 @@ export class ShowConfigurationComponent implements OnInit {
               }
             } else {
               configuration.value = data[k].toString();
+              this.configControlService.checkConfigItemValidityOnChange(this.form, configuration, this.fullConfiguration);
               const file = this.createScriptFile(data[k].toString(), configuration);
               this.event.emit({ [configuration.key]: file });
             }

--- a/src/app/services/configuration-control.service.ts
+++ b/src/app/services/configuration-control.service.ts
@@ -322,7 +322,8 @@ export class ConfigurationControlService {
       autoCloseBrackets: true,
       matchBrackets: true,
       lint: true,
-      inputStyle: 'textarea'
+      inputStyle: 'textarea',
+      readOnly: false
     };
     if (type === 'JSON') {
       editorOptions.mode = 'application/json';
@@ -371,7 +372,17 @@ export class ConfigurationControlService {
       });
       const isValidExpression = this.validateExpression(config.key, config.validityExpression);
       pluginConfiguration[config.key].validityExpression = config?.validityExpression;
+      if(!isValidExpression){
+        if(config.editorOptions.hasOwnProperty('readOnly')){
+          config.editorOptions["readOnly"] = true;
+        }
+      }
       return !isValidExpression;
+    }
+    else{
+      if(config.type === 'script'){
+        this.enableScriptEditingIfFileIsAvailable(config);
+      }
     }
   }
 
@@ -400,6 +411,11 @@ export class ConfigurationControlService {
         if (cnf.validity) {
           const isValidExpression = this.validateExpression(key, cnf.validityExpression);
           isValidExpression ? form.controls[cnf.key]?.enable({ emitEvent: false }) : form.controls[cnf.key]?.disable({ emitEvent: false });
+        }
+        else {
+          if (config.type === 'script') {
+            this.enableScriptEditingIfFileIsAvailable(config);
+          }
         }
       });
     }
@@ -513,4 +529,12 @@ export class ConfigurationControlService {
     return finalConfiguration;
   }
 
+  enableScriptEditingIfFileIsAvailable(config){
+    if (config.fileName === "" || config.fileName === null) {
+        config.editorOptions["readOnly"] = true;
+    }
+    else {
+        config.editorOptions["readOnly"] = false;
+    }
+  }
 }


### PR DESCRIPTION
CASE-1
when validity is not available for script field then code is setting disability according to the availability of file.
CASE-2
when validity is available then it is setting disability according to validity expression i. e. it is not checking the availability of file in case of validity expression.
