### PR TITLE
Validation related changes in Add API Entry Points page

### DIFF
--- a/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.css
+++ b/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.css
@@ -83,3 +83,7 @@ span.is-small {
         padding-top: 1rem;
     }
 }
+
+.input-error {
+    border: red 1px solid;
+}

--- a/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.html
+++ b/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.html
@@ -214,9 +214,9 @@
                                                 <div class="field-body" [formGroupName]="i">
                                                     <div class="field" style="max-width: 50%;">
                                                         <div class="control">
-                                                            <input formControlName="vName" placeholder="Variable name" class="input is-small"
-                                                            name="type" type="text" [ngClass]="{'is-small':rolesService.hasControlAccess(), 'is-static static-field pb-4':!rolesService.hasControlAccess()}"
-                                                            [readonly]="!rolesService.hasControlAccess()">
+                                                            <!-- Show variable name highlighted with red color if variable value exists but variable name is blank -->
+                                                            <input formControlName="vName" placeholder="Variable name" class="input is-small" name="type" type="text" [ngClass]="{'is-small':rolesService.hasControlAccess(), 'is-static static-field pb-4':!rolesService.hasControlAccess()}"
+                                                            [readonly]="!rolesService.hasControlAccess()" [ngClass]="{'input-error': (apiFlowForm.controls['variables'].controls[i].controls.vValue.value !== '' && apiFlowForm.controls['variables'].controls[i].controls.vName.value === '')}">
                                                         </div>
                                                     </div>
                                                     <div class="field" style="max-width: 50%;">
@@ -274,8 +274,9 @@
                                                 <div class="field-body" [formGroupName]="i">
                                                     <div class="field" style="max-width: 50%;">
                                                         <div class="control">
+                                                            <!-- Show constant name highlighted with red color if constant value exists but constant name is blank -->
                                                             <input formControlName="cName" placeholder="Constant name" class="input is-small" [ngClass]="{'is-small':rolesService.hasControlAccess(), 'is-static static-field pb-4':!rolesService.hasControlAccess()}"
-                                                            [readonly]="!rolesService.hasControlAccess()"
+                                                            [readonly]="!rolesService.hasControlAccess()" [ngClass]="{'input-error': (apiFlowForm.controls['constants'].controls[i].controls.cValue.value !== '' && apiFlowForm.controls['constants'].controls[i].controls.cName.value === '')}"
                                                             name="type" type="text">
                                                         </div>
                                                     </div>

--- a/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.html
+++ b/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.html
@@ -39,7 +39,7 @@
                             [readonly]="!rolesService.hasControlAccess()">
                         </div>
                         <div *ngIf="apiFlowForm.controls['name'].invalid" class="help is-danger">
-                            <div *ngIf=" apiFlowForm.controls['name'].touched && apiFlowForm.controls['name'].errors?.['required']">
+                            <div *ngIf="apiFlowForm.controls['name'].errors?.['required']">
                                 *required
                             </div>
                         </div>
@@ -396,7 +396,7 @@
                             trim="blur"></textarea>
                         </div>
                         <div *ngIf="apiFlowForm.controls['description'].invalid" class="help is-danger">
-                            <div *ngIf="apiFlowForm.controls['description'].touched && apiFlowForm.controls['description'].errors?.['required']">
+                            <div *ngIf="apiFlowForm.controls['description'].errors?.['required']">
                                 *required
                             </div>
                         </div>

--- a/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.ts
+++ b/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.ts
@@ -111,7 +111,6 @@ export class AddEditAPIFlowComponent implements OnInit {
             if (this.apiFlowName) {
               this.getAPIFlow();
             } else {
-                this.addParameter({ index: 0, key: '', value: '' });
                 this.selectedType = 'write';
             }
         });     

--- a/src/app/components/core/control-dispatcher/api-flow/api-flow.component.html
+++ b/src/app/components/core/control-dispatcher/api-flow/api-flow.component.html
@@ -8,7 +8,7 @@
                     <i class="fa fa-sm fa-sync" aria-hidden="true"></i>
                 </button>
             </div>
-            <a *ngIf="rolesService.hasControlAccess()" class="fix-pad button is-light" [routerLink]="['/control-dispatcher/entry-point/add']">
+            <a *ngIf="rolesService.hasControlAccess()" class="fix-pad button is-light" [routerLink]="['/control-dispatcher/entry-points/add']">
                 <p *ngIf="viewPort !== 'mobile'" class="add-btn">Add &nbsp;</p>
                 <i class="fa fa-xs fa-plus" aria-hidden="true"></i>
             </a>
@@ -59,7 +59,7 @@
                                     </div>
                                     <div class="dropdown-menu" id="dropdown-menu" role="menu">
                                         <div class="dropdown-content">
-                                            <a class="dropdown-item" [routerLink]="['/control-dispatcher/entry-point', ep?.name, 'details']">
+                                            <a class="dropdown-item" [routerLink]="['/control-dispatcher/entry-points', ep?.name, 'details']">
                                                 Details
                                             </a>
                                             <a *ngIf="rolesService.hasControlAccess()" class="dropdown-item"

--- a/src/app/components/core/control-dispatcher/control-dispatcher.module.ts
+++ b/src/app/components/core/control-dispatcher/control-dispatcher.module.ts
@@ -89,12 +89,12 @@ const routes: Routes = [
     component: APIFlowComponent
   },
   {
-    path: 'entry-point/add',
+    path: 'entry-points/add',
     component: AddEditAPIFlowComponent,
     canActivate: [RolesGuard]
   },
   {
-    path: 'entry-point/:name/details',
+    path: 'entry-points/:name/details',
     component: AddEditAPIFlowComponent
   }
 ];

--- a/src/styles.css
+++ b/src/styles.css
@@ -435,4 +435,8 @@ a.dropdown-item:hover {
   .lbl-child {
     font-size: 0.8rem !important;
   }
+
+  .card-header-title {
+    font-weight: 500;
+  }
  /*****************/


### PR DESCRIPTION
- [x] By default show variables/constants name and value fields closed on Add/Edit API Entry Points Page
- [x] If variables/constants value field has any value and name field is blank then show name field highlighted with red color
- [x] Show `API Entry Points` sidebar option selected when user is on Add/Edit API Entry Points Page