### PR TITLE
Filter duplication issue fixed and reordering of pipeline made smooth using drag and drop

### DIFF
--- a/src/app/components/common/node-editor/editor.ts
+++ b/src/app/components/common/node-editor/editor.ts
@@ -354,8 +354,13 @@ export function getUpdatedFilterPipeline() {
         console.log("self loop exist in pipeline")
         return false;
     }
-}
-
+  }
+  
+  // Remove duplicate connections
+  connections = connections.filter((connection, index) => {
+    return index === connections.findIndex(c => connection.source === c.source && connection.target === c.target);
+  });
+  
     let updatedFilterPipeline = [];
     let sourceNode = nodes[0];
     while (connections.find(c => c.source === sourceNode.id)) {

--- a/src/app/components/common/node-editor/editor.ts
+++ b/src/app/components/common/node-editor/editor.ts
@@ -424,13 +424,16 @@ function getBranchNodes(pipeline, connections, node) {
     if (node.label === "Storage") {
         return;
     }
+    if (existsInPipeline(pipeline, node.label)) {
+      return [];
+    }
     let branchNodes = [];
     branchNodes.push(node.label);
     while (connections.find(c => c.source === node.id)) {
         let connlist = connections.filter(c => c.source === node.id);
         if (connlist.length === 1) {
             let filterNode = editor.getNode(connlist[0].target);
-            if (existsInPipeline(pipeline, filterNode.label) || existsInPipeline(branchNodes, filterNode.label)) {
+            if (filterNode.label !== "Storage" && (existsInPipeline(pipeline, filterNode.label) || existsInPipeline(branchNodes, filterNode.label))) {
                 return [];
             }
             branchNodes.push(filterNode.label);
@@ -489,7 +492,7 @@ function rgbToHex(r, g, b) {
 
 function existsInPipeline(pipeline, filterName) {
     for (let i = 0; i < pipeline.length; i++) {
-        if (typeof (pipeline[i] === "string")) {
+        if (typeof (pipeline[i]) === "string") {
             if (pipeline[i] === filterName) {
                 return true;
             }

--- a/src/app/components/common/node-editor/editor.ts
+++ b/src/app/components/common/node-editor/editor.ts
@@ -69,9 +69,6 @@ export async function createEditor(container: HTMLElement, injector: Injector, f
 
   insertableNodes(area, {
     async createConnections(node, connection) {
-      if(node.label === "South" || node.label === "Storage" || node.label === "North"){
-        return;
-      }
       removeOldConnection(node.id)
       await editor.addConnection(
         new Connection(

--- a/src/app/components/common/node-editor/editor.ts
+++ b/src/app/components/common/node-editor/editor.ts
@@ -282,16 +282,6 @@ async function createNodesAndConnections(socket: ClassicPreset.Socket,
     else {
         nodesGrid(area, data.services, socket, rolesService, data.from);
     }
-
-
-    addCustomBackground(area);
-    // AreaExtensions.simpleNodesOrder(area);
-    AreaExtensions.selectableNodes(area, AreaExtensions.selector(), {
-        accumulating: AreaExtensions.accumulateOnCtrl()
-    });
-    AreaExtensions.restrictor(area, {
-        scaling: () => ({ min: 0.5, max: 2 }),
-    });
 }
 
 function setCustomBackground(area: AreaPlugin<Schemes, AreaExtra>,) {
@@ -540,7 +530,9 @@ async function removeOldConnection(nodeId) {
       new ClassicPreset.Connection(source, "port", t, "port")
     );
   }
-  await editor.removeConnection(inputConnId);
+  if(inputConnId){
+    await editor.removeConnection(inputConnId);
+  }
   for (let c of outputConnections) {
     await editor.removeConnection(c);
   }

--- a/src/app/components/common/node-editor/editor.ts
+++ b/src/app/components/common/node-editor/editor.ts
@@ -69,6 +69,10 @@ export async function createEditor(container: HTMLElement, injector: Injector, f
 
   insertableNodes(area, {
     async createConnections(node, connection) {
+      if(node.label === "South" || node.label === "Storage" || node.label === "North"){
+        return;
+      }
+      removeOldConnection(node.id)
       await editor.addConnection(
         new Connection(
           editor.getNode(connection.source),
@@ -513,4 +517,31 @@ export function removeNode(nodeId) {
         editor.removeConnection(c.id);
     }
     editor.removeNode(nodeId);
+}
+
+async function removeOldConnection(nodeId) {
+  let connections = editor.getConnections();
+  let source: Node;
+  let target: Node[] = [];
+  let inputConnId;
+  let outputConnections = [];
+  for (let i = 0; i < connections.length; i++) {
+    if (connections[i].source === nodeId) {
+      target.push(editor.getNode(connections[i].target));
+      outputConnections.push(connections[i].id);
+    }
+    if (connections[i].target === nodeId) {
+      source = editor.getNode(connections[i].source);
+      inputConnId = connections[i].id;
+    }
+  }
+  for (let t of target) {
+    await editor.addConnection(
+      new ClassicPreset.Connection(source, "port", t, "port")
+    );
+  }
+  await editor.removeConnection(inputConnId);
+  for (let c of outputConnections) {
+    await editor.removeConnection(c);
+  }
 }

--- a/src/app/components/common/node-editor/insert-node/index.ts
+++ b/src/app/components/common/node-editor/insert-node/index.ts
@@ -1,13 +1,14 @@
-import { BaseSchemes, GetSchemes, NodeEditor } from "rete";
+import { ClassicPreset, GetSchemes, NodeEditor } from "rete";
 import { AreaPlugin } from "rete-area-plugin";
 import { Size } from "rete-area-plugin/_types/types";
 import { Position } from "./types";
 import { checkElementIntersectPath } from "./utils";
+import { North } from "../nodes/north";
+import { South } from "../nodes/south";
 
-type Schemes = GetSchemes<
-  BaseSchemes["Node"] & Size,
-  BaseSchemes["Connection"]
->;
+type Node = South | North;
+type Schemes = GetSchemes<Node & Size, Connection<Node, Node>>;
+class Connection<A extends Node, B extends Node> extends ClassicPreset.Connection<A, B> { };
 
 export function checkIntersection(
   position: Position,
@@ -52,7 +53,7 @@ export function insertableNodes<S extends Schemes>(
         ([id, view]) => [id, view.element] as const
       );
 
-      if (view) {
+      if (view && node.label !== "South" && node.label !== "Storage" && node.label !== "North") {
         const intersectedConnections = checkIntersection(view.position, node, cons);   
 
         for(let id of intersectedConnections){

--- a/src/app/components/common/node-editor/insert-node/index.ts
+++ b/src/app/components/common/node-editor/insert-node/index.ts
@@ -13,7 +13,7 @@ export function checkIntersection(
   position: Position,
   size: { width: number; height: number },
   connections: (readonly [string, HTMLElement])[]
-): false | string {
+) {
   const paths = connections.map(([id, element]) => {
     const path = element.querySelector("path");
 
@@ -22,13 +22,14 @@ export function checkIntersection(
     return [id, element, path] as const;
   });
 
-  for (const [id, , path] of paths) {
+  let intersectedConnections = []
+  for (const [id, , path] of paths.reverse()) {
     if (checkElementIntersectPath({ ...position, ...size }, path)) {
-      return id;
+      intersectedConnections.push(id);
     }
   }
 
-  return false;
+  return intersectedConnections;
 }
 
 type Props<S extends Schemes> = {
@@ -52,9 +53,9 @@ export function insertableNodes<S extends Schemes>(
       );
 
       if (view) {
-        const id = checkIntersection(view.position, node, cons);
+        const intersectedConnections = checkIntersection(view.position, node, cons);   
 
-        if (id) {
+        for(let id of intersectedConnections){
           const exist = editor.getConnection(id);
 
           if (exist.source !== node.id && exist.target !== node.id) {


### PR DESCRIPTION
**Issues fixed**:

- When a filter from a branch is moved to another branch via drag and drop, its previous connection should be broken automatically
- Creating connection between 2 branches of pipeline creates a duplicate filter
- Unable to insert first filter of pipeline between second last and last filter of pipeline on drag and drop
- Remove connections which have same source and same destination