### PR TITLE
FOGL-8306.patch1: Show timestamp in the alert dropdown

### DIFF
--- a/src/app/components/core/system-alert/system-alert.component.css
+++ b/src/app/components/core/system-alert/system-alert.component.css
@@ -42,3 +42,7 @@
     border-radius: 2px;
     border: lightgray solid 1px;
 }
+
+.align-timestamp {
+    padding-left: 1.7rem !important;
+}

--- a/src/app/components/core/system-alert/system-alert.component.css
+++ b/src/app/components/core/system-alert/system-alert.component.css
@@ -9,7 +9,7 @@
     font-size: 0.7rem;
     color: white;
     text-align: center;
-    border-radius: 28%;
+    border-radius: 12%;
     position: absolute;
     top: -11px;
     left: 11px;

--- a/src/app/components/core/system-alert/system-alert.component.css
+++ b/src/app/components/core/system-alert/system-alert.component.css
@@ -9,7 +9,7 @@
     font-size: 0.7rem;
     color: white;
     text-align: center;
-    border-radius: 35%;
+    border-radius: 28%;
     position: absolute;
     top: -11px;
     left: 11px;
@@ -38,7 +38,8 @@
 }
 
 #alerts {
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
     border-radius: 2px;
     border: lightgray solid 1px;
 }

--- a/src/app/components/core/system-alert/system-alert.component.css
+++ b/src/app/components/core/system-alert/system-alert.component.css
@@ -36,3 +36,9 @@
     display: flex;
     align-items: center;
 }
+
+#alerts {
+    overflow: hidden;
+    border-radius: 2px;
+    border: lightgray solid 1px;
+}

--- a/src/app/components/core/system-alert/system-alert.component.html
+++ b/src/app/components/core/system-alert/system-alert.component.html
@@ -1,6 +1,6 @@
 <div id="dropdown" class="dropdown is-right" id="system-alert-dd">
   <div class="dropdown-trigger">
-    <a class="button is-small system-alert" aria-haspopup="true" aria-controls="dropdown-menu" (click)="toggleDropdown()">
+    <a class="button is-small system-alert" [title]="alertsCount === 0 ? 'No Alerts' : 'Alerts'" aria-haspopup="true" aria-controls="dropdown-menu" (click)="toggleDropdown()">
       <span class="icon icon-badge-container">
         <i class="bi bi-bell bi-lg" aria-hidden="true"></i>
         <div class="icon-badge">{{alertsCount}}</div>
@@ -8,25 +8,24 @@
     </a>
   </div>
   <div class="dropdown-menu" id="dropdown-menu" role="menu">
-    <div class="dropdown-content">
+    <div class="dropdown-content" id="alerts">
       <ng-container *ngFor="let alert of systemAlerts; let i=index;">
-        <div class="columns dropdown-item pb-0">
-          <a class="column is-vertical-center is-1">
+        <div class="columns dropdown-item">
+          <span class="column is-vertical-center is-1">
             <i [ngClass]="applyClass(alert?.urgency)" class="bi bi bi-exclamation-triangle"></i>          
-          </a>
+          </span>
           <div class="column">
             <div class="message-text">
               {{alert.message}}
             </div>
           </div>
         </div>
-        <div class="columns mb-0 mr-1">
-          <!-- TODO: Show timestamp -->
-          <!-- <div class="column is-1">
+        <div class="columns p-0 mb-0 mr-1">
+          <div class="column is-1">
           </div>
-          <div class="column is-pulled-right">
-            <span class="help">1m ago</span>
-          </div> -->
+          <div class="column is-pulled-right pt-1 pb-0">
+            <span class="help">{{getAlertTime(alert?.timestamp)}}</span>
+          </div>
           <ng-container *ngIf="rolesService.hasEditPermissions()">
             <div class="column pt-0 pb-0">
               <div class="field is-grouped is-pulled-right">          

--- a/src/app/components/core/system-alert/system-alert.component.html
+++ b/src/app/components/core/system-alert/system-alert.component.html
@@ -10,7 +10,7 @@
   <div class="dropdown-menu" id="dropdown-menu" role="menu">
     <div class="dropdown-content" id="alerts">
       <ng-container *ngFor="let alert of systemAlerts; let i=index;">
-        <div class="columns dropdown-item">
+        <div class="columns dropdown-item" [ngClass]="{'pb-0 mb-0': !rolesService.hasEditPermissions()}">
           <span class="column is-vertical-center is-1">
             <i [ngClass]="applyClass(alert?.urgency)" class="bi bi bi-exclamation-triangle"></i>          
           </span>
@@ -19,18 +19,19 @@
               {{alert.message}}
             </div>
           </div>
+          
         </div>
         <div class="columns p-0 mb-0 mr-1">
           <div class="column is-1">
           </div>
-          <div class="column is-pulled-right pt-1 pb-0">
-            <span class="help">{{getAlertTime(alert?.timestamp)}}</span>
+          <div class="column pt-1 pb-0 pl-5" [ngClass]="{'align-timestamp': !rolesService.hasEditPermissions()}">
+            <span class="help has-text-grey">{{getAlertTime(alert?.timestamp)}}</span>
           </div>
           <ng-container *ngIf="rolesService.hasEditPermissions()">
             <div class="column pt-0 pb-0">
               <div class="field is-grouped is-pulled-right">          
-                <p class="control">
-                  <button class="button is-tiny is-outlined is-link" (click)="performAction(alert)">{{getButtonText(alert?.message)}}</button>
+                <p *ngIf="['Show Logs', 'Upgrade'].includes(alert?.buttonText)" class="control">
+                  <button class="button is-tiny is-outlined is-link" (click)="performAction(alert)">{{alert?.buttonText}}</button>
                 </p>
                 <p class="control">
                   <button class="button is-tiny" (click)="deleteAlert(alert?.key)" [appDisableUntilResponse]="reenableButton">Hide</button>

--- a/src/app/components/core/system-alert/system-alert.component.ts
+++ b/src/app/components/core/system-alert/system-alert.component.ts
@@ -42,7 +42,7 @@ export class SystemAlertComponent {
   getAlerts() {
     this.systemAlertService.getAlerts().
     subscribe(
-      (data) => {       
+      (data) => {   
         data['alerts'].forEach(alert => {         
           alert['buttonText'] = this.getButtonText(alert.message);
         });

--- a/src/app/components/core/system-alert/system-alert.component.ts
+++ b/src/app/components/core/system-alert/system-alert.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, EventEmitter } from '@angular/core';
-import { AlertService, SystemAlertService, ProgressBarService, RolesService } from '../../../services';
+import { Component, Input, EventEmitter, HostListener } from '@angular/core';
+import { AlertService, ProgressBarService, RolesService, SystemAlertService } from '../../../services';
 import { SystemAlert, SystemAlerts } from './../../../models/system-alert';
 import { Router } from '@angular/router';
 
@@ -20,6 +20,13 @@ export class SystemAlertComponent {
     private systemAlertService: SystemAlertService,
     public ngProgress: ProgressBarService,
     private rolesService: RolesService) {
+  }
+
+  @HostListener('document:keydown.escape', ['$event']) onKeydownHandler() {
+    const dropDown = document.querySelector('#system-alert-dd');
+    if (dropDown.classList.contains('is-active')) {
+      dropDown.classList.remove('is-active');
+    }
   }
 
   ngOnInit() {}
@@ -119,10 +126,23 @@ export class SystemAlertComponent {
       return "has-text-warning";
     }
     if (urgency.toLowerCase() === "normal") {
-      return "has-text-warning-light";
+      return "has-text-grey-light";
     }
     if (urgency.toLowerCase() === "low") {
-      return "has-text-info-light";
+      return "text-grey-lighter";
     }
+  }
+
+  getAlertTime(timestamp: Date) {
+    const moment = require('moment');
+    const alertTimestamp = moment.utc(timestamp);
+    
+    // Get the current time
+    const currentTime = moment().utc();
+    
+    const timeDifference = alertTimestamp.isAfter(currentTime) ?
+    alertTimestamp.fromNow() : 
+    alertTimestamp.from(currentTime);
+    return timeDifference;
   }
 }

--- a/src/app/components/core/system-alert/system-alert.component.ts
+++ b/src/app/components/core/system-alert/system-alert.component.ts
@@ -42,7 +42,10 @@ export class SystemAlertComponent {
   getAlerts() {
     this.systemAlertService.getAlerts().
     subscribe(
-      (data) => {
+      (data) => {       
+        data['alerts'].forEach(alert => {         
+          alert['buttonText'] = this.getButtonText(alert.message);
+        });
         this.systemAlerts = data['alerts'];
       },
       error => {
@@ -56,10 +59,10 @@ export class SystemAlertComponent {
   }
 
   performAction(alert: SystemAlert) {
-    if (this.getButtonText(alert.message) === 'Show Logs') {
+    if (alert['buttonText'] === 'Show Logs') {
       this.router.navigate(['logs/syslog'], { queryParams: { source: alert.key } });
     }
-    if (this.getButtonText(alert.message) === 'Upgrade') {
+    if (alert['buttonText'] === 'Upgrade') {
       this.update();
     }
     this.toggleDropdown();

--- a/src/app/components/core/system-alert/system-alert.component.ts
+++ b/src/app/components/core/system-alert/system-alert.component.ts
@@ -139,13 +139,8 @@ export class SystemAlertComponent {
   getAlertTime(timestamp: Date) {
     const moment = require('moment');
     const alertTimestamp = moment.utc(timestamp);
-    
-    // Get the current time
-    const currentTime = moment().utc();
-    
-    const timeDifference = alertTimestamp.isAfter(currentTime) ?
-    alertTimestamp.fromNow() : 
-    alertTimestamp.from(currentTime);
+    const currentTime = moment().utc(); 
+    const timeDifference = alertTimestamp.isAfter(currentTime) ? alertTimestamp.fromNow() : alertTimestamp.from(currentTime);
     return timeDifference;
   }
 }

--- a/src/app/components/core/system-alert/system-alert.component.ts
+++ b/src/app/components/core/system-alert/system-alert.component.ts
@@ -42,11 +42,11 @@ export class SystemAlertComponent {
   getAlerts() {
     this.systemAlertService.getAlerts().
     subscribe(
-      (data) => {   
-        data['alerts'].forEach(alert => {         
+      (data: SystemAlerts) => {   
+        data.alerts.forEach(alert => {         
           alert['buttonText'] = this.getButtonText(alert.message);
         });
-        this.systemAlerts = data['alerts'].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        this.systemAlerts = data.alerts.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
       },
       error => {
         if (error.status === 0) {

--- a/src/app/components/core/system-alert/system-alert.component.ts
+++ b/src/app/components/core/system-alert/system-alert.component.ts
@@ -46,7 +46,7 @@ export class SystemAlertComponent {
         data['alerts'].forEach(alert => {         
           alert['buttonText'] = this.getButtonText(alert.message);
         });
-        this.systemAlerts = data['alerts'];
+        this.systemAlerts = data['alerts'].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
       },
       error => {
         if (error.status === 0) {


### PR DESCRIPTION
**Done:**

- [x] Show timestamp like now, x seconds ago, 1 minute ago, 20 minutes ago, 1 days ago, 1 week ago based on setting in settings page
- [x] Sorted by timestamp
- [x] When no action buttons padding/margin at bottom should be same as on top.
- [x] If text does not contain updates or restarted then don’t show action button
- [x] UI fixes

**Pending:**

- [ ] Group by urgency, group itself sorted by ts (list by urgency group)
- [ ] If message is longer then 2 lines then elipsize ...
- [ ] At bottom after divider if alerts length > 1, Add Hide all ghost button in right and Sort by Timestamp or Sort by Urgency (toggle) in the left 
- [ ] Delete last remaining alert, an empty dropdown remains until the next ping; and bell icon disappears. Bell icon should not disappear but badge should be removed and that empty dropdown. Bell icon hover title in this case should be No Alerts