### PR TITLE
Deprecate asset button added & per asset reading count shown in quickview

### DIFF
--- a/src/app/components/common/node-editor/controls/common-custom-control.ts
+++ b/src/app/components/common/node-editor/controls/common-custom-control.ts
@@ -12,6 +12,12 @@ export class PluginControl extends ClassicPreset.Control {
   }
 }
 
+export class PluginVersionControl extends ClassicPreset.Control {
+  constructor(public pluginVersion: string) {
+    super();
+  }
+}
+
 export class StatusControl extends ClassicPreset.Control {
   constructor(public status: string) {
     super();

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.css
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.css
@@ -98,6 +98,14 @@
   font-size: 0.8rem;
 }
 
+.custom-tooltip::before {
+  left: 20% !important;
+}
+
+.custom-tooltip::after {
+  left: 20% !important;
+}
+
 .service-details {
   display: flex;
   justify-content: center;

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.html
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.html
@@ -62,7 +62,7 @@
     <div>
       <ng-container *ngIf="isServiceNode && from != 'north'">
         <readings-count *ngIf="service" [readingCount]="service.readingCount"
-          [assetCount]="service.assetCount"></readings-count>
+          [assetCount]="service.assetCount" [serviceName]="service.name"></readings-count>
       </ng-container>
       <ng-container *ngIf="isServiceNode && from == 'north'">
         <div class="reading-details">

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.html
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.html
@@ -119,9 +119,9 @@
             (click)="showLogsInQuickview()">
             <i class="bi bi-file-earmark-text bi-xs"></i>
           </span>
-          <span *ngIf="isServiceNode && from=='south' && service.readingCount>0"
+          <span *ngIf="isServiceNode && from=='south'" [hidden]="service.readingCount==0"
             class="icon is-small has-tooltip-bottom has-tooltip-arrow tooltip is-pulled-left is-hovered help-icon ml-3"
-            data-tooltip="Show readings" data-show="quickview" data-target="quickviewDefault"
+            data-tooltip="Show readings" [attr.data-show]="'quickview'" [attr.data-target]="'quickviewDefault'"
             (click)="showReadingsPerAsset()">
             <i class="bi bi-table bi-xs"></i>
           </span>
@@ -151,8 +151,8 @@
                     <span>Details</span>
                   </a>
                 </ng-container>
-                <ng-container *ngIf="isServiceNode && from=='south' && service.readingCount>0">
-                  <a class="dropdown-item" data-show="quickview" data-target="quickviewDefault" (click)="showReadingsPerAsset()">
+                <ng-container *ngIf="isServiceNode && from=='south'">
+                  <a class="dropdown-item" [attr.data-show]="'quickview'" [attr.data-target]="'quickviewDefault'" [hidden]="service.readingCount==0" (click)="showReadingsPerAsset()">
                     <span>Readings</span>
                   </a>
                 </ng-container>

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.html
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.html
@@ -119,11 +119,11 @@
             (click)="showLogsInQuickview()">
             <i class="far fa-xs fa-file-alt"></i>
           </span>
-          <span *ngIf="isServiceNode && from=='south'"
+          <span *ngIf="isServiceNode && from=='south' && service.readingCount>0"
             class="icon is-small has-tooltip-bottom has-tooltip-arrow tooltip is-pulled-left is-hovered help-icon ml-3"
             data-tooltip="Show readings" data-show="quickview" data-target="quickviewDefault"
             (click)="showReadingsPerAsset()">
-            <i class="fa fa-xs fa-chart-line"></i>
+            <i class="bi bi-table bi-xs"></i>
           </span>
         </div>
       </ng-container>
@@ -151,7 +151,7 @@
                     <span>Details</span>
                   </a>
                 </ng-container>
-                <ng-container *ngIf="isServiceNode && from=='south'">
+                <ng-container *ngIf="isServiceNode && from=='south' && service.readingCount>0">
                   <a class="dropdown-item" data-show="quickview" data-target="quickviewDefault" (click)="showReadingsPerAsset()">
                     <span>Readings</span>
                   </a>

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.html
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.html
@@ -156,6 +156,11 @@
                     <span>Readings</span>
                   </a>
                 </ng-container>
+                <ng-container *ngIf="isServiceNode && from=='south' && service.readingCount>0">
+                  <a class="dropdown-item" (click)="getAssetReadings()">
+                    <span>Export Readings</span>
+                  </a>
+                </ng-container>
                 <a *ngIf="rolesService.hasEditPermissions()" class="dropdown-item" (click)="deleteFilterOrService()">
                   <span>Delete</span>
                 </a>

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.html
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.html
@@ -119,6 +119,12 @@
             (click)="showLogsInQuickview()">
             <i class="far fa-xs fa-file-alt"></i>
           </span>
+          <span *ngIf="isServiceNode && from=='south'"
+            class="icon is-small has-tooltip-bottom has-tooltip-arrow tooltip is-pulled-left is-hovered help-icon ml-3"
+            data-tooltip="Show readings" data-show="quickview" data-target="quickviewDefault"
+            (click)="showReadingsPerAsset()">
+            <i class="fa fa-xs fa-chart-line"></i>
+          </span>
         </div>
       </ng-container>
       <div class="is-pulled-right">
@@ -143,6 +149,11 @@
                 <ng-container *ngIf="!source">
                   <a class="dropdown-item" (click)="openServiceDetails()">
                     <span>Details</span>
+                  </a>
+                </ng-container>
+                <ng-container *ngIf="isServiceNode && from=='south'">
+                  <a class="dropdown-item" data-show="quickview" data-target="quickviewDefault" (click)="showReadingsPerAsset()">
+                    <span>Readings</span>
                   </a>
                 </ng-container>
                 <a *ngIf="rolesService.hasEditPermissions()" class="dropdown-item" (click)="deleteFilterOrService()">

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.html
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.html
@@ -111,13 +111,13 @@
         <div class="is-pulled-left ml-2 icon-margin">
           <span class="icon is-small has-tooltip-right has-tooltip-arrow tooltip is-pulled-left is-hovered"
             data-tooltip="Help" (click)="goToLink()">
-            <i class="far fa-xs fa-question-circle"></i>
+            <i class="bi bi-question-circle bi-xs"></i>
           </span>
           <span *ngIf="isServiceNode"
             class="icon is-small has-tooltip-right has-tooltip-arrow tooltip is-pulled-left is-hovered help-icon ml-3"
             data-tooltip="Show logs" data-show="quickview" data-target="quickviewDefault"
             (click)="showLogsInQuickview()">
-            <i class="far fa-xs fa-file-alt"></i>
+            <i class="bi bi-file-earmark-text bi-xs"></i>
           </span>
           <span *ngIf="isServiceNode && from=='south' && service.readingCount>0"
             class="icon is-small has-tooltip-bottom has-tooltip-arrow tooltip is-pulled-left is-hovered help-icon ml-3"

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.html
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.html
@@ -56,7 +56,8 @@
           </ng-template>
         </div>
       </div>
-      <span *ngIf="data.label!=='Filter'" class="help-text">{{helpText}}</span>
+      <span *ngIf="isFilterNode && data.label!=='Filter'" class="help-text">{{helpText}}</span>
+      <span *ngIf="isServiceNode" class="help-text has-tooltip-bottom custom-tooltip has-tooltip-arrow tooltip is-hovered" [attr.data-tooltip]="pluginVersion">{{helpText}}</span>
     </div>
     <div>
       <ng-container *ngIf="isServiceNode && from != 'north'">

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.ts
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.ts
@@ -423,6 +423,10 @@ export class CustomNodeComponent implements OnChanges {
     this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: false, showFilterConfiguration: false, showLogs: false, showReadings: true, serviceName: this.service.name });
   }
 
+  getAssetReadings() {
+    this.flowEditorService.exportReading.next({serviceName: this.service.name});
+  }
+
   ngOnDestroy() {
     this.subscription.unsubscribe();
     this.addFilterSubscription?.unsubscribe();

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.ts
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.ts
@@ -222,15 +222,15 @@ export class CustomNodeComponent implements OnChanges {
 
   showConfigurationInQuickview() {
     if (this.isServiceNode) {
-      this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: true, showFilterConfiguration: false, showLogs: false, serviceName: this.service.name });
+      this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: true, serviceName: this.service.name });
     }
     else {
-      this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: false, showFilterConfiguration: true, showLogs: false, serviceName: this.source, filterName: this.filter.name });
+      this.flowEditorService.showItemsInQuickview.next({ showFilterConfiguration: true, serviceName: this.source, filterName: this.filter.name });
     }
   }
 
   showLogsInQuickview() {
-    this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: false, showFilterConfiguration: false, showLogs: true, serviceName: this.service.name });
+    this.flowEditorService.showItemsInQuickview.next({ showLogs: true, serviceName: this.service.name });
   }
 
   navToSyslogs() {
@@ -322,7 +322,7 @@ export class CustomNodeComponent implements OnChanges {
   }
 
   openTaskSchedule() {
-    this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: false, showFilterConfiguration: false, showLogs: false, showTaskSchedule: true, serviceName: this.service.name });
+    this.flowEditorService.showItemsInQuickview.next({ showTaskSchedule: true, serviceName: this.service.name });
   }
 
   openServiceDetails() {
@@ -420,7 +420,7 @@ export class CustomNodeComponent implements OnChanges {
   }
 
   showReadingsPerAsset() {
-    this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: false, showFilterConfiguration: false, showLogs: false, showReadings: true, serviceName: this.service.name });
+    this.flowEditorService.showItemsInQuickview.next({ showReadings: true, serviceName: this.service.name });
   }
 
   getAssetReadings() {

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.ts
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.ts
@@ -419,6 +419,10 @@ export class CustomNodeComponent implements OnChanges {
     this.flowEditorService.removeFilter.next({ id: this.nodeId });
   }
 
+  showReadingsPerAsset() {
+    this.flowEditorService.showItemsInQuickview.next({ showPluginConfiguration: false, showFilterConfiguration: false, showLogs: false, showReadings: true, serviceName: this.service.name });
+  }
+
   ngOnDestroy() {
     this.subscription.unsubscribe();
     this.addFilterSubscription?.unsubscribe();

--- a/src/app/components/common/node-editor/custom-node/custom-node.component.ts
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.ts
@@ -47,7 +47,8 @@ export class CustomNodeComponent implements OnChanges {
     pluginName: "",
     assetCount: "",
     readingCount: "",
-    schedule_enabled: false
+    schedule_enabled: false,
+    pluginVersion: ""
   }
   task = {
     name: "",
@@ -60,9 +61,10 @@ export class CustomNodeComponent implements OnChanges {
     processName: "",
     repeat: "",
     sent: "",
-    taskStatus: {}
+    taskStatus: {},
+    pluginVersion: ""
   }
-  filter = { pluginName: '', enabled: 'false', name: '', color: '' }
+  filter = { pluginName: '', enabled: 'false', name: '', color: '', pluginVersion: "" }
   isServiceNode: boolean = false;
   subscription: Subscription;
   addFilterSubscription: Subscription;
@@ -74,6 +76,7 @@ export class CustomNodeComponent implements OnChanges {
   showPlusIcon = false;
   showDeleteIcon = false;
   nodeId = '';
+  pluginVersion = '';
 
   @HostBinding("class.selected") get selected() {
     return this.data.selected;
@@ -122,9 +125,11 @@ export class CustomNodeComponent implements OnChanges {
             this.task.sent = this.service.readingCount = this.data.controls.sentReadingControl['sent'];
             this.task.execution = this.data.controls.executionControl['execution'];
             this.task.enabled = this.data.controls.enabledControl['enabled'];
+            this.task.pluginVersion = this.service.pluginVersion = this.data.controls.pluginVersionControl['pluginVersion'];
             this.isEnabled = this.task.enabled;
             this.helpText = this.task.plugin;
             this.pluginName = this.task.plugin;
+            this.pluginVersion = this.task.pluginVersion;
           }
         } else {
           if (!isEmpty(this.data.controls)) {
@@ -134,9 +139,11 @@ export class CustomNodeComponent implements OnChanges {
             this.service.readingCount = this.data.controls.readingCountControl['count'];
             this.service.status = this.data.controls.statusControl['status'];
             this.service.schedule_enabled = this.data.controls.enabledControl['enabled'];
+            this.service.pluginVersion = this.data.controls.pluginVersionControl['pluginVersion'];
             this.isEnabled = this.service.schedule_enabled;
             this.helpText = this.service.pluginName;
             this.pluginName = this.service.pluginName;
+            this.pluginVersion = this.service.pluginVersion;
           }
         }
       }

--- a/src/app/components/common/node-editor/editor.ts
+++ b/src/app/components/common/node-editor/editor.ts
@@ -26,7 +26,7 @@ import { North } from "./nodes/north";
 import { AddTask } from "./nodes/add-task";
 import { RolesService } from "../../../services/roles.service"
 import { Service } from "../../core/south/south-service";
-import { ReadingControl } from "./controls/south-custom-control";
+import { AssetControl, ReadingControl } from "./controls/south-custom-control";
 import { SentReadingsControl } from './controls/north-custom-control';
 import { EnabledControl, NameControl, PluginControl, StatusControl } from './controls/common-custom-control';
 import { NorthTask } from '../../core/north/north-task';
@@ -458,20 +458,24 @@ export function updateFilterNode(filterConfiguration) {
 
 export function updateNode(data) {
   editor.getNodes().forEach(async (node) => {
+    const assetControls = node.controls.assetCountControl as AssetControl
     const readingControl = node.controls.readingCountControl as ReadingControl;
     const enabledControl = node.controls.enabledControl as EnabledControl;
     const statusControl = node.controls.statusControl as StatusControl;
     if (!isEmpty(node.controls)) {
       if (node.label == 'South') {
         const service = data.services.find(s => s.name === node.controls.nameControl['name'])
+        let assetCount = service.assets.length;
         let readingCount = service.assets.reduce((total, asset) => {
           return total + asset.count;
         }, 0)
 
+        assetControls.count = assetCount;
         readingControl.count = readingCount;
         enabledControl.enabled = service.schedule_enabled;
         statusControl.status = service.status;
 
+        area.update("control", assetControls.id);
         area.update("control", readingControl.id);
         area.update("control", enabledControl.id);
         area.update("control", statusControl.id);

--- a/src/app/components/common/node-editor/flow-editor.module.ts
+++ b/src/app/components/common/node-editor/flow-editor.module.ts
@@ -16,6 +16,7 @@ import { PluginService } from '../../../services/plugin.service';
 import { AddTaskWizardComponent } from '../../core/north/add-task-wizard/add-task-wizard.component';
 import { ReadingsCountComponent } from './south/asset-readings/readings-count.component';
 import { DirectivesModule } from '../../../directives/directives.module';
+import { AssetTrackerComponent } from './south/asset-tracker/asset-tracker.component';
 
 const routes: Routes = [
   {
@@ -47,7 +48,8 @@ const routes: Routes = [
     CustomSocketComponent,
     CustomConnectionComponent,
     ReadingsCountComponent,
-    RefDirective],
+    RefDirective,
+    AssetTrackerComponent],
   imports: [
     RouterModule.forChild(routes),
     CommonModule,

--- a/src/app/components/common/node-editor/flow-editor.service.ts
+++ b/src/app/components/common/node-editor/flow-editor.service.ts
@@ -14,6 +14,7 @@ export class FlowEditorService {
   public showAddFilterIcon: BehaviorSubject<any> = new BehaviorSubject<any>(false);
   public serviceInfo: BehaviorSubject<any> = new BehaviorSubject<any>(false);
   public removeFilter: BehaviorSubject<any> = new BehaviorSubject<any>(false);
+  public exportReading: BehaviorSubject<any> = new BehaviorSubject<any>(false);
   constructor() { }
 
   public flowEditorControl(visible: boolean) {

--- a/src/app/components/common/node-editor/node-editor.component.css
+++ b/src/app/components/common/node-editor/node-editor.component.css
@@ -12,24 +12,3 @@
 .breadcrumb {
   display: inline-block;
 }
-
-.readings-count {
-  vertical-align: middle;
-  max-width: max-content;
-}
-
-.deprecate {
-  padding-right: 10px;
-  color: #363636;
-}
-
-.table {
-  font-size: 0.9em;
-}
-
-.readings-breadcrumb {
-  padding-top: 0.85rem;
-  margin-top: 10px;
-  font-size: 0.95rem;
-  margin-bottom: 0.25rem !important;
-}

--- a/src/app/components/common/node-editor/node-editor.component.css
+++ b/src/app/components/common/node-editor/node-editor.component.css
@@ -22,3 +22,7 @@
   padding-right: 10px;
   color: #363636;
 }
+
+.table {
+  font-size: 0.9em;
+}

--- a/src/app/components/common/node-editor/node-editor.component.css
+++ b/src/app/components/common/node-editor/node-editor.component.css
@@ -12,3 +12,13 @@
 .breadcrumb {
   display: inline-block;
 }
+
+.readings-count {
+  vertical-align: middle;
+  max-width: max-content;
+}
+
+.deprecate {
+  padding-right: 10px;
+  color: #363636;
+}

--- a/src/app/components/common/node-editor/node-editor.component.css
+++ b/src/app/components/common/node-editor/node-editor.component.css
@@ -26,3 +26,10 @@
 .table {
   font-size: 0.9em;
 }
+
+.readings-breadcrumb {
+  padding-top: 0.85rem;
+  margin-top: 10px;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem !important;
+}

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -75,47 +75,7 @@
       <app-task-schedule [taskSchedule]="taskSchedule"></app-task-schedule>
     </ng-container>
     <ng-container *ngIf="showReadings">
-      <div class="container is-fluid">
-        <nav class="breadcrumb readings-breadcrumb" aria-label="breadcrumbs">
-          <ul>
-            <li class="is-active"><a>{{serviceName}}</a></li>
-            <li class="is-active">
-              <a href="#" aria-current="page">Readings</a>
-            </li>
-          </ul>
-        </nav>
-        <table class="table is-responsive mt-4">
-          <thead>
-            <tr>
-              <th class="align-th">Asset</th>
-              <th></th>
-              <th class="align-th">Readings Count</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr *ngFor='let data of service?.assets'>
-                <td>
-                  <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
-                    class="deprecate"
-                    (click)="selectAsset(data?.asset);openModal('asset-tracking-dialog')">
-                    <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
-                      data-tooltip="Deprecate asset">
-                      <i class="bi bi-eraser"></i>
-                    </span>
-                  </a>
-                  <small>{{data.asset}}</small>
-                </td>
-                <td>
-                </td>
-                <td class="readings-count">
-                  <small class="level-right">{{data.count | number}}</small>
-                </td>
-            </tr>
-          </tbody>
-        </table>
-        <button [appDisableUntilResponse]="reenableButton"
-          class="button is-small" (click)="getAssetReadings(service)">Export Readings</button>
-      </div>
+      <app-asset-tracker [service]="service" (selectedAsset)="selectAsset($event)"></app-asset-tracker>
     </ng-container>
   </app-quickview>
 </div>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -75,8 +75,9 @@
       <app-task-schedule [taskSchedule]="taskSchedule"></app-task-schedule>
     </ng-container>
     <ng-container *ngIf="showReadings">
-      <app-asset-tracker [service]="readingService" [isAlive]="isAlive" (selectedAsset)="selectAsset($event)"
-      (reloadReadings)="getSouthervices()"></app-asset-tracker>
+      <app-asset-tracker [service]="readingService" [isAlive]="isAlive" [reenableButton]="reenableButton"
+      (selectedAsset)="selectAsset($event)"
+      (reloadReadings)="getSouthervices()" (exportReading)="getAssetReadings(readingService)"></app-asset-tracker>
     </ng-container>
   </app-quickview>
 </div>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -75,7 +75,8 @@
       <app-task-schedule [taskSchedule]="taskSchedule"></app-task-schedule>
     </ng-container>
     <ng-container *ngIf="showReadings">
-      <app-asset-tracker [service]="service" (selectedAsset)="selectAsset($event)"></app-asset-tracker>
+      <app-asset-tracker [service]="readingService" [isAlive]="isAlive" (selectedAsset)="selectAsset($event)"
+      (reloadReadings)="getSouthervices()"></app-asset-tracker>
     </ng-container>
   </app-quickview>
 </div>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -83,7 +83,7 @@
                 (click)="selectAsset(data?.asset);openModal('asset-tracking-dialog')">
                 <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
                   data-tooltip="Deprecate asset">
-                  <i class="fa fa-sm fa-eraser" aria-hidden="true"></i>
+                  <i class="bi bi-eraser"></i>
                 </span>
               </a>
               <small>{{data.asset}}</small>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -113,6 +113,8 @@
             </tr>
           </tbody>
         </table>
+        <button [appDisableUntilResponse]="reenableButton"
+          class="button is-small" (click)="getAssetReadings(service)">Export Readings</button>
       </div>
     </ng-container>
   </app-quickview>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -75,26 +75,36 @@
       <app-task-schedule [taskSchedule]="taskSchedule"></app-task-schedule>
     </ng-container>
     <ng-container *ngIf="showReadings">
-      <table class="table is-narrow is-responsive">
-        <tr *ngFor='let data of service?.assets'>
-            <td>
-              <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
-                class="deprecate"
-                (click)="selectAsset(data?.asset);openModal('asset-tracking-dialog')">
-                <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
-                  data-tooltip="Deprecate asset">
-                  <i class="bi bi-eraser"></i>
-                </span>
-              </a>
-              <small>{{data.asset}}</small>
-            </td>
-            <td>
-            </td>
-            <td class="readings-count">
-              <small class="level-right">{{data.count | number}}</small>
-            </td>
-        </tr>
-      </table>
+      <div class="container is-fluid">
+        <nav class="breadcrumb readings-breadcrumb" aria-label="breadcrumbs">
+          <ul>
+            <li class="is-active"><a>{{serviceName}}</a></li>
+            <li class="is-active">
+              <a href="#" aria-current="page">Readings</a>
+            </li>
+          </ul>
+        </nav>
+        <table class="table is-responsive mt-4">
+          <tr *ngFor='let data of service?.assets'>
+              <td>
+                <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
+                  class="deprecate"
+                  (click)="selectAsset(data?.asset);openModal('asset-tracking-dialog')">
+                  <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
+                    data-tooltip="Deprecate asset">
+                    <i class="bi bi-eraser"></i>
+                  </span>
+                </a>
+                <small>{{data.asset}}</small>
+              </td>
+              <td>
+              </td>
+              <td class="readings-count">
+                <small class="level-right">{{data.count | number}}</small>
+              </td>
+          </tr>
+        </table>
+      </div>
     </ng-container>
   </app-quickview>
 </div>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -85,24 +85,33 @@
           </ul>
         </nav>
         <table class="table is-responsive mt-4">
-          <tr *ngFor='let data of service?.assets'>
-              <td>
-                <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
-                  class="deprecate"
-                  (click)="selectAsset(data?.asset);openModal('asset-tracking-dialog')">
-                  <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
-                    data-tooltip="Deprecate asset">
-                    <i class="bi bi-eraser"></i>
-                  </span>
-                </a>
-                <small>{{data.asset}}</small>
-              </td>
-              <td>
-              </td>
-              <td class="readings-count">
-                <small class="level-right">{{data.count | number}}</small>
-              </td>
-          </tr>
+          <thead>
+            <tr>
+              <th class="align-th">Asset</th>
+              <th></th>
+              <th class="align-th">Readings Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor='let data of service?.assets'>
+                <td>
+                  <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
+                    class="deprecate"
+                    (click)="selectAsset(data?.asset);openModal('asset-tracking-dialog')">
+                    <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
+                      data-tooltip="Deprecate asset">
+                      <i class="bi bi-eraser"></i>
+                    </span>
+                  </a>
+                  <small>{{data.asset}}</small>
+                </td>
+                <td>
+                </td>
+                <td class="readings-count">
+                  <small class="level-right">{{data.count | number}}</small>
+                </td>
+            </tr>
+          </tbody>
         </table>
       </div>
     </ng-container>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -40,7 +40,7 @@
     </div>
   </ng-contafiner>
   <!-- Quick View -->
-  <app-quickview>
+  <app-quickview [showReadings]="showReadings">
     <ng-container *ngIf="showPluginConfiguration">
       <app-configuration-group *ngIf="category" [category]="category" [from]="'south'" [sourceName]="serviceName"
         (changedConfigEvent)="getChangedConfig($event)"

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -74,6 +74,28 @@
     <ng-container *ngIf="showTaskSchedule">
       <app-task-schedule [taskSchedule]="taskSchedule"></app-task-schedule>
     </ng-container>
+    <ng-container *ngIf="showReadings">
+      <table class="table is-narrow is-responsive">
+        <tr *ngFor='let data of service?.assets'>
+            <td>
+              <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
+                class="deprecate"
+                (click)="selectAsset(data?.asset);openModal('asset-tracking-dialog')">
+                <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
+                  data-tooltip="Deprecate asset">
+                  <i class="fa fa-sm fa-eraser" aria-hidden="true"></i>
+                </span>
+              </a>
+              <small>{{data.asset}}</small>
+            </td>
+            <td>
+            </td>
+            <td class="readings-count">
+              <small class="level-right">{{data.count | number}}</small>
+            </td>
+        </tr>
+      </table>
+    </ng-container>
   </app-quickview>
 </div>
 
@@ -109,3 +131,17 @@
   </footer>
 </app-confirmation-dialog>
 <!-- <app-task-schedule #taskScheduleComponent [taskSchedule]="taskSchedule"></app-task-schedule> -->
+
+<app-confirmation-dialog id="asset-tracking-dialog">
+  <header class="modal-card-head">
+    <span class="modal-card-title is-size-6">Deprecate</span>
+    <button class="delete" aria-label="close" (click)="closeModal('asset-tracking-dialog')"></button>
+  </header>
+  <section class="modal-card-body">
+    Are you sure, <b>{{selectedAsset}}</b> will be deprecated if this action is continued?
+  </section>
+  <footer class="modal-card-foot">
+    <button class="button is-small" (click)="closeModal('asset-tracking-dialog')">Cancel</button>
+    <button class="button is-small is-danger" (click)="deprecateAsset(selectedAsset)">Yes</button>
+  </footer>
+</app-confirmation-dialog>

--- a/src/app/components/common/node-editor/node-editor.component.ts
+++ b/src/app/components/common/node-editor/node-editor.component.ts
@@ -54,6 +54,7 @@ export class NodeEditorComponent implements OnInit {
   showTaskSchedule = false;
   showReadings = false;
   service: Service;
+  readingService: Service;
   task: NorthTask;
   services: Service[] = [];
   tasks: NorthTask[] = [];
@@ -151,7 +152,7 @@ export class NodeEditorComponent implements OnInit {
         this.getFilterCategory()
       }
       if(this.showReadings) {
-        this.service = this.services.find(service => (service.name == this.serviceName));
+        this.readingService = this.services.find(service => (service.name == this.serviceName));
       }
     });
 
@@ -341,6 +342,7 @@ export class NodeEditorComponent implements OnInit {
       .subscribe((data: any) => {
         const services = data.services as Service[];
         this.services = services;
+        this.readingService = this.services.find(service => (service.name == this.serviceName));
         data = {
           from: this.from,
           source: this.source,
@@ -807,6 +809,7 @@ export class NodeEditorComponent implements OnInit {
   }
 
   ngOnDestroy() {
+    this.isAlive = false;
     this.subscription.unsubscribe();
     this.filterSubscription.unsubscribe();
     this.connectionSubscription.unsubscribe();

--- a/src/app/components/common/node-editor/node-editor.component.ts
+++ b/src/app/components/common/node-editor/node-editor.component.ts
@@ -127,11 +127,11 @@ export class NodeEditorComponent implements OnInit {
   }
   ngOnInit(): void {
     this.subscription = this.flowEditorService.showItemsInQuickview.pipe(skip(1)).subscribe(data => {
-      this.showPluginConfiguration = data.showPluginConfiguration;
-      this.showFilterConfiguration = data.showFilterConfiguration;
-      this.showLogs = data.showLogs;
-      this.showTaskSchedule = data.showTaskSchedule;
-      this.showReadings = data.showReadings;
+      this.showPluginConfiguration = data.showPluginConfiguration ? true: false;
+      this.showFilterConfiguration = data.showFilterConfiguration ? true: false;
+      this.showLogs = data.showLogs ? true: false;
+      this.showTaskSchedule = data.showTaskSchedule ? true: false;
+      this.showReadings = data.showReadings ? true: false;
       this.serviceName = data.serviceName;
       if (this.showPluginConfiguration) {
         this.getCategory();

--- a/src/app/components/common/node-editor/node-editor.component.ts
+++ b/src/app/components/common/node-editor/node-editor.component.ts
@@ -97,7 +97,6 @@ export class NodeEditorComponent implements OnInit {
     private dialogService: DialogService,
     private northService: NorthService,
     private ping: PingService,
-    public developerFeaturesService: DeveloperFeaturesService,
     private assetService: AssetsService,
     public generateCsv: GenerateCsvService,
     private router: Router) {
@@ -730,8 +729,9 @@ export class NodeEditorComponent implements OnInit {
     this.router.navigate(['/flow/editor', this.from, this.source, 'details']);
   }
 
-  selectAsset(assetName: string) {
-    this.selectedAsset = assetName;
+  selectAsset(event) {
+    this.selectedAsset = event.assetName;
+    this.openModal('asset-tracking-dialog');
   }
 
   deprecateAsset(assetName: string) {

--- a/src/app/components/common/node-editor/nodes/north.ts
+++ b/src/app/components/common/node-editor/nodes/north.ts
@@ -3,6 +3,7 @@ import {
   EnabledControl,
   NameControl,
   PluginControl,
+  PluginVersionControl,
   StatusControl
 } from "../controls/common-custom-control";
 import { ExecutionControl, SentReadingsControl } from "../controls/north-custom-control";
@@ -22,6 +23,7 @@ export class North extends ClassicPreset.Node {
       const status = new StatusControl(task?.status);
       const execution = new ExecutionControl(task?.execution);
       const enabled = new EnabledControl(task.enabled);
+      const pluginVersion = new PluginVersionControl(task.plugin.version);
 
       this.addControl('nameControl', name);
       this.addControl('pluginControl', plugin);
@@ -29,6 +31,7 @@ export class North extends ClassicPreset.Node {
       this.addControl('executionControl', execution);
       this.addControl('sentReadingControl', sentReading);
       this.addControl('enabledControl', enabled);
+      this.addControl('pluginVersionControl', pluginVersion);
     }
   }
 }

--- a/src/app/components/common/node-editor/nodes/south.ts
+++ b/src/app/components/common/node-editor/nodes/south.ts
@@ -7,6 +7,7 @@ import {
   EnabledControl,
   NameControl,
   PluginControl,
+  PluginVersionControl,
   StatusControl
 } from "../controls/common-custom-control";
 
@@ -29,6 +30,7 @@ export class South extends ClassicPreset.Node {
       const enabledControl = new EnabledControl(service.schedule_enabled);
       const readingCountControl = new ReadingControl(readingCount);
       const assetCountControl = new AssetControl(assetCount);
+      const pluginVersion = new PluginVersionControl(service.plugin.version);
 
       this.addControl('nameControl', nameControl);
       this.addControl('pluginControl', pluginControl);
@@ -36,6 +38,7 @@ export class South extends ClassicPreset.Node {
       this.addControl('assetCountControl', assetCountControl);
       this.addControl('statusControl', statusControl);
       this.addControl('enabledControl', enabledControl);
+      this.addControl('pluginVersionControl', pluginVersion);
     }
     this.addOutput("port", new ClassicPreset.Output(socket));
   }

--- a/src/app/components/common/node-editor/south/asset-readings/readings-count.component.html
+++ b/src/app/components/common/node-editor/south/asset-readings/readings-count.component.html
@@ -1,5 +1,5 @@
 <div class="reading-details">
-    <ng-container *ngIf="readingsCount && readingsCount!==0; else zeroReadingTemplate">
+    <ng-container *ngIf="+readingCount!==0; else zeroReadingTemplate">
         <small class="reading has-tooltip-top has-tooltip-arrow"
           data-tooltip="Reading count"  data-show="quickview" data-target="quickviewDefault"
           (click)="showReadingsPerAsset()">{{readingCount}}</small>

--- a/src/app/components/common/node-editor/south/asset-readings/readings-count.component.html
+++ b/src/app/components/common/node-editor/south/asset-readings/readings-count.component.html
@@ -1,0 +1,16 @@
+<div class="reading-details">
+    <ng-container *ngIf="readingsCount && readingsCount!==0; else zeroReadingTemplate">
+        <small class="reading has-tooltip-top has-tooltip-arrow"
+          data-tooltip="Reading count"  data-show="quickview" data-target="quickviewDefault"
+          (click)="showReadingsPerAsset()">{{readingCount}}</small>
+        <small class="asset has-tooltip-top has-tooltip-arrow"
+          data-tooltip="Asset count"  data-show="quickview" data-target="quickviewDefault"
+          (click)="showReadingsPerAsset()">{{assetCount}}</small>
+    </ng-container>
+    <ng-template #zeroReadingTemplate>
+        <small class="reading has-tooltip-top has-tooltip-arrow"
+          data-tooltip="Reading count">{{readingCount}}</small>
+        <small class="asset has-tooltip-top has-tooltip-arrow"
+          data-tooltip="Asset count">{{assetCount}}</small>
+    </ng-template>
+</div>

--- a/src/app/components/common/node-editor/south/asset-readings/readings-count.component.html
+++ b/src/app/components/common/node-editor/south/asset-readings/readings-count.component.html
@@ -1,16 +1,14 @@
 <div class="reading-details">
-    <ng-container *ngIf="+readingCount!==0; else zeroReadingTemplate">
-        <small class="reading has-tooltip-top has-tooltip-arrow"
-          data-tooltip="Reading count"  data-show="quickview" data-target="quickviewDefault"
-          (click)="showReadingsPerAsset()">{{readingCount}}</small>
-        <small class="asset has-tooltip-top has-tooltip-arrow"
-          data-tooltip="Asset count"  data-show="quickview" data-target="quickviewDefault"
-          (click)="showReadingsPerAsset()">{{assetCount}}</small>
-    </ng-container>
-    <ng-template #zeroReadingTemplate>
-        <small class="reading has-tooltip-top has-tooltip-arrow"
-          data-tooltip="Reading count">{{readingCount}}</small>
-        <small class="asset has-tooltip-top has-tooltip-arrow"
-          data-tooltip="Asset count">{{assetCount}}</small>
-    </ng-template>
+  <small class="reading has-tooltip-top has-tooltip-arrow"
+    data-tooltip="Reading count"  data-show="quickview" data-target="quickviewDefault"
+    (click)="showReadingsPerAsset()" [hidden]="+readingCount==0">{{readingCount}}</small>
+  <small class="asset has-tooltip-top has-tooltip-arrow"
+    data-tooltip="Asset count"  data-show="quickview" data-target="quickviewDefault"
+    (click)="showReadingsPerAsset()" [hidden]="+readingCount==0">{{assetCount}}</small>
+  <ng-container *ngIf="+readingCount==0">
+    <small class="reading has-tooltip-top has-tooltip-arrow"
+      data-tooltip="Reading count">{{readingCount}}</small>
+    <small class="asset has-tooltip-top has-tooltip-arrow"
+      data-tooltip="Asset count">{{assetCount}}</small>
+  </ng-container>
 </div>

--- a/src/app/components/common/node-editor/south/asset-readings/readings-count.component.ts
+++ b/src/app/components/common/node-editor/south/asset-readings/readings-count.component.ts
@@ -1,18 +1,24 @@
 import { Component, Input } from '@angular/core';
 import { AssetControl, ReadingControl } from '../../controls/south-custom-control';
+import { FlowEditorService } from '../../flow-editor.service';
 
 @Component({
   selector: 'readings-count',
-  template: `<div class="reading-details">
-                <small class="reading has-tooltip-top has-tooltip-arrow"
-                  data-tooltip="Reading count">{{readingCount}}</small>
-                <small class="asset has-tooltip-top has-tooltip-arrow"
-                  data-tooltip="Asset count">{{assetCount}}</small>
-        </div>`,
+  templateUrl: './readings-count.component.html',
   styleUrls: ['./readings-count.component.css'],
 })
 export class ReadingsCountComponent {
   @Input() readingCount: ReadingControl;
   @Input() assetCount: AssetControl;
-  constructor() { }
+  @Input() serviceName;
+  readingsCount;
+  constructor(public flowEditorService: FlowEditorService) { }
+  
+  ngOnInit(){
+    this.readingsCount = this.readingCount;
+  }
+  
+  showReadingsPerAsset() {
+    this.flowEditorService.showItemsInQuickview.next({ showReadings: true, serviceName: this.serviceName });
+  }
 }

--- a/src/app/components/common/node-editor/south/asset-readings/readings-count.component.ts
+++ b/src/app/components/common/node-editor/south/asset-readings/readings-count.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core';
-import { AssetControl, ReadingControl } from '../../controls/south-custom-control';
 import { FlowEditorService } from '../../flow-editor.service';
 
 @Component({
@@ -8,15 +7,10 @@ import { FlowEditorService } from '../../flow-editor.service';
   styleUrls: ['./readings-count.component.css'],
 })
 export class ReadingsCountComponent {
-  @Input() readingCount: ReadingControl;
-  @Input() assetCount: AssetControl;
+  @Input() readingCount: string;
+  @Input() assetCount: string;
   @Input() serviceName;
-  readingsCount;
   constructor(public flowEditorService: FlowEditorService) { }
-  
-  ngOnInit(){
-    this.readingsCount = this.readingCount;
-  }
   
   showReadingsPerAsset() {
     this.flowEditorService.showItemsInQuickview.next({ showReadings: true, serviceName: this.serviceName });

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.css
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.css
@@ -1,0 +1,20 @@
+.readings-count {
+  vertical-align: middle;
+  max-width: max-content;
+}
+
+.deprecate {
+  padding-right: 10px;
+  color: #363636;
+}
+
+.table {
+  font-size: 0.9em;
+}
+
+.readings-breadcrumb {
+  padding-top: 0.85rem;
+  margin-top: 10px;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem !important;
+}

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.css
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.css
@@ -17,4 +17,5 @@
   margin-top: 10px;
   font-size: 0.95rem;
   margin-bottom: 0.25rem !important;
+  display: inline-block;
 }

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
@@ -40,5 +40,5 @@
       </tbody>
     </table>
     <button [appDisableUntilResponse]="reenableButton"
-      class="button is-small is-ghost" (click)="getAssetReadings(service)">Export Readings</button>
+      class="button is-small is-ghost" (click)="exportReadings()">Export Readings</button>
   </div>

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
@@ -7,6 +7,9 @@
         </li>
       </ul>
     </nav>
+    <button type="button" *ngIf="!isAlive" (click)="reload()" title="Reload" class="button is-small" id="refresh-check">
+        <i class="fa fa-sm fa-sync" aria-hidden="true"></i>
+    </button>
     <table class="table is-responsive mt-6 ml-2">
       <thead>
         <tr>

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
@@ -1,0 +1,41 @@
+<div class="container is-fluid">
+    <nav class="breadcrumb readings-breadcrumb" aria-label="breadcrumbs">
+      <ul>
+        <li class="is-active"><a>{{service.name}}</a></li>
+        <li class="is-active">
+          <a href="#" aria-current="page">Readings</a>
+        </li>
+      </ul>
+    </nav>
+    <table class="table is-responsive mt-4">
+      <thead>
+        <tr>
+          <th class="align-th">Asset</th>
+          <th></th>
+          <th class="align-th">Readings Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor='let data of service?.assets'>
+            <td>
+              <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
+                class="deprecate"
+                (click)="selectAsset(data?.asset)">
+                <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
+                  data-tooltip="Deprecate asset">
+                  <i class="bi bi-eraser"></i>
+                </span>
+              </a>
+              <small>{{data.asset}}</small>
+            </td>
+            <td>
+            </td>
+            <td class="readings-count">
+              <small class="level-right">{{data.count | number}}</small>
+            </td>
+        </tr>
+      </tbody>
+    </table>
+    <button [appDisableUntilResponse]="reenableButton"
+      class="button is-small" (click)="getAssetReadings(service)">Export Readings</button>
+  </div>

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
@@ -29,12 +29,12 @@
                   <i class="bi bi-eraser"></i>
                 </span>
               </a>
-              <small>{{data.asset}}</small>
+              <span>{{data.asset}}</span>
             </td>
             <td>
             </td>
             <td class="readings-count">
-              <small class="level-right">{{data.count | number}}</small>
+              <span class="level-right">{{data.count | number}}</span>
             </td>
         </tr>
       </tbody>

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
@@ -7,12 +7,12 @@
         </li>
       </ul>
     </nav>
-    <table class="table is-responsive mt-4">
+    <table class="table is-responsive mt-6 ml-2">
       <thead>
         <tr>
           <th class="align-th">Asset</th>
           <th></th>
-          <th class="align-th">Readings Count</th>
+          <th class="align-th">Readings</th>
         </tr>
       </thead>
       <tbody>
@@ -37,5 +37,5 @@
       </tbody>
     </table>
     <button [appDisableUntilResponse]="reenableButton"
-      class="button is-small" (click)="getAssetReadings(service)">Export Readings</button>
+      class="button is-small is-ghost" (click)="getAssetReadings(service)">Export Readings</button>
   </div>

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.spec.ts
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AssetTrackerComponent } from './asset-tracker.component';
+
+describe('AssetTrackerComponent', () => {
+  let component: AssetTrackerComponent;
+  let fixture: ComponentFixture<AssetTrackerComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [AssetTrackerComponent]
+    });
+    fixture = TestBed.createComponent(AssetTrackerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
@@ -1,10 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Subject } from 'rxjs';
-import { AssetsService, GenerateCsvService, ProgressBarService, RolesService, ToastService } from '../../../../../services';
+import { RolesService } from '../../../../../services';
 import { DeveloperFeaturesService } from '../../../../../services/developer-features.service';
-import { MAX_INT_SIZE } from '../../../../../utils';
-import { FlowEditorService } from '../../flow-editor.service';
-import { Service } from '../../../../core/south/south-service';
 
 @Component({
   selector: 'app-asset-tracker',
@@ -14,74 +11,23 @@ import { Service } from '../../../../core/south/south-service';
 export class AssetTrackerComponent {
 
   destroy$: Subject<boolean> = new Subject<boolean>();
-  public reenableButton = new EventEmitter<boolean>(false);
+  @Input() reenableButton = new EventEmitter<boolean>(false);
   @Input()service;
   @Input()isAlive;
   @Output() selectedAsset = new EventEmitter<Object>();
   @Output() reloadReadings = new EventEmitter<Object>();
-  MAX_RANGE = MAX_INT_SIZE / 2;
+  @Output() exportReading = new EventEmitter<Object>();
 
   constructor(public developerFeaturesService: DeveloperFeaturesService,
-    public flowEditorService: FlowEditorService,
-    private toastService: ToastService,
-    public rolesService: RolesService,
-    public ngProgress: ProgressBarService,
-    private assetService: AssetsService,
-    public generateCsv: GenerateCsvService) {
+    public rolesService: RolesService) {
   }
 
   selectAsset(assetName: string) {
     this.selectedAsset.emit({assetName: assetName});
   }
 
-  getAssetReadings(service: Service) {
-    const fileName = service.name + '-readings';
-    const assets = service.assets;
-    const assetRecord: any = [];
-    if (assets.length === 0) {
-      this.toastService.error('No readings to export.');
-      return;
-    }
-    this.toastService.info('Exporting readings to ' + fileName);
-    assets.forEach((ast: any) => {
-      let limit = ast.count;
-      let offset = 0;
-      if (ast.count > this.MAX_RANGE) {
-        limit = this.MAX_RANGE;
-        const chunkCount = Math.ceil(ast.count / this.MAX_RANGE);
-        let lastChunkLimit = (ast.count % this.MAX_RANGE);
-        if (lastChunkLimit === 0) {
-          lastChunkLimit = this.MAX_RANGE;
-        }
-        for (let j = 0; j < chunkCount; j++) {
-          if (j !== 0) {
-            offset = (this.MAX_RANGE * j);
-          }
-          if (j === (chunkCount - 1)) {
-            limit = lastChunkLimit;
-          }
-          assetRecord.push({ asset: ast.asset, limit: limit, offset: offset });
-        }
-      } else {
-        assetRecord.push({ asset: ast.asset, limit: limit, offset: offset });
-      }
-    });
-    this.exportReadings(assetRecord, fileName);
-  }
-
-  exportReadings(assets: [], fileName: string) {
-    let assetReadings = [];
-    this.assetService.getMultiAssetsReadings(assets).
-      subscribe(
-        (result: any) => {
-          this.reenableButton.emit(false);
-          assetReadings = [].concat.apply([], result);
-          this.generateCsv.download(assetReadings, fileName, 'service');
-        },
-        error => {
-          this.reenableButton.emit(false);
-          console.log('error in response', error);
-        });
+  exportReadings() {
+    this.exportReading.emit(true);
   }
 
   reload() {

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
@@ -16,7 +16,9 @@ export class AssetTrackerComponent {
   destroy$: Subject<boolean> = new Subject<boolean>();
   public reenableButton = new EventEmitter<boolean>(false);
   @Input()service;
+  @Input()isAlive;
   @Output() selectedAsset = new EventEmitter<Object>();
+  @Output() reloadReadings = new EventEmitter<Object>();
   MAX_RANGE = MAX_INT_SIZE / 2;
 
   constructor(public developerFeaturesService: DeveloperFeaturesService,
@@ -80,6 +82,10 @@ export class AssetTrackerComponent {
           this.reenableButton.emit(false);
           console.log('error in response', error);
         });
+  }
+
+  reload() {
+    this.reloadReadings.emit(true);
   }
 
   ngOnDestroy() {

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 import { RolesService } from '../../../../../services';
 import { DeveloperFeaturesService } from '../../../../../services/developer-features.service';
+import { Service } from '../../../../core/south/south-service';
 
 @Component({
   selector: 'app-asset-tracker',
@@ -10,10 +11,9 @@ import { DeveloperFeaturesService } from '../../../../../services/developer-feat
 })
 export class AssetTrackerComponent {
 
-  destroy$: Subject<boolean> = new Subject<boolean>();
   @Input() reenableButton = new EventEmitter<boolean>(false);
-  @Input()service;
-  @Input()isAlive;
+  @Input() service: Service;
+  @Input() isAlive: boolean;
   @Output() selectedAsset = new EventEmitter<Object>();
   @Output() reloadReadings = new EventEmitter<Object>();
   @Output() exportReading = new EventEmitter<Object>();
@@ -32,10 +32,5 @@ export class AssetTrackerComponent {
 
   reload() {
     this.reloadReadings.emit(true);
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next(true);
-    this.destroy$.unsubscribe();
   }
 }

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.ts
@@ -1,0 +1,89 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Subject } from 'rxjs';
+import { AssetsService, GenerateCsvService, ProgressBarService, RolesService, ToastService } from '../../../../../services';
+import { DeveloperFeaturesService } from '../../../../../services/developer-features.service';
+import { MAX_INT_SIZE } from '../../../../../utils';
+import { FlowEditorService } from '../../flow-editor.service';
+import { Service } from '../../../../core/south/south-service';
+
+@Component({
+  selector: 'app-asset-tracker',
+  templateUrl: './asset-tracker.component.html',
+  styleUrls: ['./asset-tracker.component.css']
+})
+export class AssetTrackerComponent {
+
+  destroy$: Subject<boolean> = new Subject<boolean>();
+  public reenableButton = new EventEmitter<boolean>(false);
+  @Input()service;
+  @Output() selectedAsset = new EventEmitter<Object>();
+  MAX_RANGE = MAX_INT_SIZE / 2;
+
+  constructor(public developerFeaturesService: DeveloperFeaturesService,
+    public flowEditorService: FlowEditorService,
+    private toastService: ToastService,
+    public rolesService: RolesService,
+    public ngProgress: ProgressBarService,
+    private assetService: AssetsService,
+    public generateCsv: GenerateCsvService) {
+  }
+
+  selectAsset(assetName: string) {
+    this.selectedAsset.emit({assetName: assetName});
+  }
+
+  getAssetReadings(service: Service) {
+    const fileName = service.name + '-readings';
+    const assets = service.assets;
+    const assetRecord: any = [];
+    if (assets.length === 0) {
+      this.toastService.error('No readings to export.');
+      return;
+    }
+    this.toastService.info('Exporting readings to ' + fileName);
+    assets.forEach((ast: any) => {
+      let limit = ast.count;
+      let offset = 0;
+      if (ast.count > this.MAX_RANGE) {
+        limit = this.MAX_RANGE;
+        const chunkCount = Math.ceil(ast.count / this.MAX_RANGE);
+        let lastChunkLimit = (ast.count % this.MAX_RANGE);
+        if (lastChunkLimit === 0) {
+          lastChunkLimit = this.MAX_RANGE;
+        }
+        for (let j = 0; j < chunkCount; j++) {
+          if (j !== 0) {
+            offset = (this.MAX_RANGE * j);
+          }
+          if (j === (chunkCount - 1)) {
+            limit = lastChunkLimit;
+          }
+          assetRecord.push({ asset: ast.asset, limit: limit, offset: offset });
+        }
+      } else {
+        assetRecord.push({ asset: ast.asset, limit: limit, offset: offset });
+      }
+    });
+    this.exportReadings(assetRecord, fileName);
+  }
+
+  exportReadings(assets: [], fileName: string) {
+    let assetReadings = [];
+    this.assetService.getMultiAssetsReadings(assets).
+      subscribe(
+        (result: any) => {
+          this.reenableButton.emit(false);
+          assetReadings = [].concat.apply([], result);
+          this.generateCsv.download(assetReadings, fileName, 'service');
+        },
+        error => {
+          this.reenableButton.emit(false);
+          console.log('error in response', error);
+        });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next(true);
+    this.destroy$.unsubscribe();
+  }
+}

--- a/src/app/components/common/quickview/quickview.component.html
+++ b/src/app/components/common/quickview/quickview.component.html
@@ -1,6 +1,6 @@
 <div id="quickviewDefault" class="quickview" #quickView>
     <div class="quickview-body">
-        <div class="quickview-block">
+        <div class="quickview-block" #quickViewBlock>
             <ng-content></ng-content>
         </div>
         <span class="delete mt-5 mr-2" data-dismiss="quickview"></span>

--- a/src/app/components/common/quickview/quickview.component.ts
+++ b/src/app/components/common/quickview/quickview.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit, ViewChild } from '@angular/core';
+import { Component, HostListener, Input, OnInit, ViewChild } from '@angular/core';
 import * as bulmaQuickview from './../../../../../node_modules/bulma-quickview/dist/js/bulma-quickview.min.js'
 
 @Component({
@@ -9,6 +9,7 @@ import * as bulmaQuickview from './../../../../../node_modules/bulma-quickview/d
 export class QuickviewComponent implements OnInit {
 
   @ViewChild('quickView') quickView;
+  @Input() showReadings;
 
   constructor() {
   }
@@ -27,6 +28,16 @@ export class QuickviewComponent implements OnInit {
         clearInterval(intervalId)
       }
     }, 100)
+  }
+
+  ngOnChanges() {
+    if(this.showReadings){
+      this.quickView.nativeElement.style.width = '35%';
+      return;
+    }
+    if(this.quickView){
+      this.quickView.nativeElement.style.width = '66%';
+    }
   }
 
 }

--- a/src/app/components/common/quickview/quickview.component.ts
+++ b/src/app/components/common/quickview/quickview.component.ts
@@ -10,7 +10,7 @@ export class QuickviewComponent implements OnInit {
 
   @ViewChild('quickView') quickView;
   @ViewChild('quickViewBlock') quickViewBlock;
-  @Input() showReadings;
+  @Input() showReadings: boolean;
 
   constructor() {
   }

--- a/src/app/components/common/quickview/quickview.component.ts
+++ b/src/app/components/common/quickview/quickview.component.ts
@@ -9,6 +9,7 @@ import * as bulmaQuickview from './../../../../../node_modules/bulma-quickview/d
 export class QuickviewComponent implements OnInit {
 
   @ViewChild('quickView') quickView;
+  @ViewChild('quickViewBlock') quickViewBlock;
   @Input() showReadings;
 
   constructor() {
@@ -33,10 +34,12 @@ export class QuickviewComponent implements OnInit {
   ngOnChanges() {
     if(this.showReadings){
       this.quickView.nativeElement.style.width = '35%';
+      this.quickViewBlock.nativeElement.style.width = '80%';
       return;
     }
     if(this.quickView){
       this.quickView.nativeElement.style.width = '66%';
+      this.quickViewBlock.nativeElement.style.width = '95%';
     }
   }
 


### PR DESCRIPTION
**Issues fixed**: 

- Show per asset reading count in quickview
- Add deprecate asset button if developer features are on
- Add icon for per asset reading count on node and also add option in context menu
- Show plugin version on hover of plugin name
- Add export readings button in context menu and in quickview
- Open readings table in quickview on click of reading count, asset count in node
- Bind reading table values with ping
- Reduce quickview size for readings table