### PR TITLE
FOGL:8574: added custom token in providers  for AlertService & ngProgress service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -109,7 +109,10 @@ export function pingServiceFactory(ping: PingService, sharedService: SharedServi
   providers: [
     AuthRequiredGuard,
     DataViewRoleGuard,
-    AlertService,
+    {
+      provide: 'ALERT_SERVICE',
+      useExisting: AlertService,
+    },
     AuthService,
     ConfigurationService,
     AuditService,
@@ -131,7 +134,10 @@ export function pingServiceFactory(ping: PingService, sharedService: SharedServi
     PingService,
     NorthService,
     SchedulesService,
-    ProgressBarService,
+    {
+      provide: 'PROGRESS_SERVICE',
+      useExisting: ProgressBarService,
+    },
     UserService,
     {
       provide: HTTP_INTERCEPTORS,

--- a/src/app/services/alert.service.ts
+++ b/src/app/services/alert.service.ts
@@ -4,7 +4,11 @@ import { Observable, Subject } from 'rxjs';
 
 export const DARK_ALERTS = 1;
 
-@Injectable()
+@Injectable(
+  {
+    providedIn: 'root'
+  }
+)
 export class AlertService {
   private subject = new Subject<any>();
   private keepAfterNavigationChange = false;


### PR DESCRIPTION
Custom token change is required to use the service in the ML modal GUI component without duplication of the service code. 

  