### PR TITLE
UI enhancement done in flow editor view

### DIFF
--- a/src/app/components/common/node-editor/custom-node/custom-node.component.css
+++ b/src/app/components/common/node-editor/custom-node/custom-node.component.css
@@ -11,6 +11,10 @@
   user-select: none;
 }
 
+:host:has(div.add-service) {
+  border: 2px dotted silver !important;
+}
+
 :host:hover {
   background: whitesmoke;
 }

--- a/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.css
+++ b/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.css
@@ -99,7 +99,7 @@
 }
 
 .add-notification {
-  height: 110px;
+  height: 92px;
   width: 198px;
   display: flex;
   justify-content: center;
@@ -145,4 +145,15 @@
 
 .bulb-on {
   color: #dab600;
+}
+
+.is-custom-center {
+  position: absolute;
+  left: 53%;
+  transform: translateX(-50%);
+  width: max-content;
+}
+
+.title {
+  line-height: 0.9;
 }

--- a/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.css
+++ b/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.css
@@ -11,6 +11,10 @@
   user-select: none;
 }
 
+:host:has(div.add-notification) {
+  border: 2px dotted silver !important;
+}
+
 :host:hover {
   background: whitesmoke;
 }

--- a/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.css
+++ b/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.css
@@ -140,7 +140,7 @@
 }
 
 .onhover-text {
-  height: 0.7rem;
+  height: 0.9rem;
 }
 
 .bulb-on {
@@ -156,4 +156,8 @@
 
 .title {
   line-height: 0.9;
+}
+
+.description-text {
+  max-width: 7rem !important;
 }

--- a/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
+++ b/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
@@ -6,7 +6,7 @@
           <span>{{data.controls?.nameControl?.name}}
             <i [ngClass]="notification.enable ? 'bulb-on': 'has-text-grey-light'" class="fa-regular fa-lightbulb icon-rule"></i>
             <p class="onhover-text">
-              <span class="help-text" [hidden]="!showPluginName">{{notification.rule}}</span>
+              <span class="help-text pt-1" [hidden]="!showPluginName">{{notification.rule}}</span>
             </p>
           </span>
         </div>
@@ -23,13 +23,6 @@
         </div>
       </div>
     </div>
-    <div class="columns mb-0 is-centered">
-      <div class="column is-half">
-        <span class="is-hovered has-text-grey-light">
-          <span class="is-custom-center onhover-text help-text" [hidden]="!showPluginName">{{notification.channel}}</span>
-        </span>
-      </div>
-    </div>
     <div class="columns is-centered">
       <div class="column is-half">
         <span>
@@ -37,7 +30,14 @@
         </span>
       </div>
     </div>
-    <div>
+    <div class="columns mb-0 is-centered">
+      <div class="column is-half">
+        <span class="is-hovered has-text-grey-light">
+          <span class="is-custom-center onhover-text help-text" [hidden]="!showPluginName">{{notification.channel}}</span>
+        </span>
+      </div>
+    </div>
+    <div class="pt-1">
       <div class="is-pulled-left ml-2 icon-margin">
         <span class="icon is-small has-tooltip-right has-tooltip-arrow tooltip is-pulled-left is-hovered"
           data-tooltip="Help" (click)="goToLink()">
@@ -50,7 +50,7 @@
         </span>     
       </div>
       <div class="is-custom-center">
-        <span class="help-text">{{notification.notificationType}}</span>
+        <span class="help-text">{{notification.notificationType | titlecase}}</span>
       </div>
       <div class="is-pulled-right">
         <div class="dropdown is-hoverable" *ngIf="rolesService.hasEditPermissions()">

--- a/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
+++ b/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
@@ -23,14 +23,19 @@
         </div>
       </div>
     </div>
-    <div class="is-flex is-justify-content-center">
-      <span class="is-hovered has-text-grey-light">
-        <p class="onhover-text">
-          <span class="help-text" [hidden]="!showPluginName">{{notification.channel}}</span>
-        </p>
-        <i class="bi bi-lightning-charge bi-lg no-hover pl-3" [ngClass]="notification.isDeliveryEnabled === 'true' ? 'has-text-info': 'has-text-grey-light'"></i>
-        <span class="help-text">{{notification.notificationType}}</span>
-      </span>        
+    <div class="columns mb-0 is-centered">
+      <div class="column is-half">
+        <span class="is-hovered has-text-grey-light">
+          <span class="is-custom-center onhover-text help-text" [hidden]="!showPluginName">{{notification.channel}}</span>
+        </span>
+      </div>
+    </div>
+    <div class="columns is-centered">
+      <div class="column is-half">
+        <span>
+          <i class="is-custom-center bi bi-lightning-charge bi-lg no-hover" [ngClass]="notification.isDeliveryEnabled === 'true' ? 'has-text-info': 'has-text-grey-light'"></i>
+        </span>
+      </div>
     </div>
     <div>
       <div class="is-pulled-left ml-2 icon-margin">
@@ -42,7 +47,10 @@
           class="icon is-small has-tooltip-right has-tooltip-arrow tooltip is-pulled-left is-hovered help-icon ml-3"
           data-tooltip="Show logs" data-show="quickview" data-target="quickviewDefault" (click)="showLogsInQuickview()">
           <i class="bi bi-file-earmark-text bi-xs"></i>
-        </span>
+        </span>     
+      </div>
+      <div class="is-custom-center">
+        <span class="help-text">{{notification.notificationType}}</span>
       </div>
       <div class="is-pulled-right">
         <div class="dropdown is-hoverable" *ngIf="rolesService.hasEditPermissions()">

--- a/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
+++ b/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
@@ -3,8 +3,9 @@
     <div class="title" data-testid="title">
       <div class="is-flex is-justify-content-space-between is-align-items-baseline">
         <div class="is-inline-flex is-align-items-baseline">    
-          <span>{{data.controls?.nameControl?.name}}
-            <i [ngClass]="notification.enable ? 'bulb-on': 'has-text-grey-light'" class="fa-regular fa-lightbulb icon-rule"></i>
+          <i [ngClass]="notification.enable ? 'bulb-on': 'has-text-grey-light'" class="fa-regular fa-lightbulb icon-rule pr-1"></i>
+          <span class="description-text">
+            <span [title]="data.controls?.nameControl?.name">{{data.controls?.nameControl?.name}}</span>
             <p class="onhover-text">
               <span class="help-text pt-1" [hidden]="!showPluginName">{{notification.rule}}</span>
             </p>

--- a/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
+++ b/src/app/components/common/node-editor/custom-notification-node/custom-notification-node.component.html
@@ -23,17 +23,14 @@
         </div>
       </div>
     </div>
-    <div>
-      <div class="is-flex is-justify-content-center">
-        <span class="is-hovered has-text-grey-light">
-          <p class="onhover-text">
-            <span class="help-text" [hidden]="!showPluginName">{{notification.channel}}</span>
-          </p>
-          <i class="bi bi-lightning-charge bi-lg no-hover pl-3" [ngClass]="notification.isDeliveryEnabled === 'true' ? 'has-text-info': 'has-text-grey-light'"></i>
-          <span class="help-text">{{notification.notificationType}}</span>
-        </span>
-             
-      </div>
+    <div class="is-flex is-justify-content-center">
+      <span class="is-hovered has-text-grey-light">
+        <p class="onhover-text">
+          <span class="help-text" [hidden]="!showPluginName">{{notification.channel}}</span>
+        </p>
+        <i class="bi bi-lightning-charge bi-lg no-hover pl-3" [ngClass]="notification.isDeliveryEnabled === 'true' ? 'has-text-info': 'has-text-grey-light'"></i>
+        <span class="help-text">{{notification.notificationType}}</span>
+      </span>        
     </div>
     <div>
       <div class="is-pulled-left ml-2 icon-margin">

--- a/src/app/components/common/node-editor/node-editor.component.css
+++ b/src/app/components/common/node-editor/node-editor.component.css
@@ -49,7 +49,7 @@ hr {
     background-color: #fff;
 }
 
-.help-pad {
+.help-icon {
   margin: 12px 7px !important;
 }
 

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -26,7 +26,7 @@
           </li>
         </ul>
       </nav>
-      <ng-container *ngIf="source && !isAddFilterWizard">
+      <ng-container *ngIf="source && !isAddFilterWizard || from === 'notifications'">
         <button type="button" (click)="reload()" class="button is-small" title="Reload" id="refresh-check">
           <i class="fa fa-sm fa-sync" aria-hidden="true"></i>
         </button>
@@ -198,7 +198,7 @@
     <button class="delete" aria-label="close" (click)="closeModal('state-change-dialog')"></button>
   </header>
   <section class="modal-card-body">
-    Are You sure, you want to {{btnText}} the instance {{dialogServiceName}}?
+    Are you sure, You want to {{btnText.toLowerCase()}} the notification instance {{dialogServiceName}}?
   </section>
   <footer class="modal-card-foot">
     <button class="button is-small" (click)="closeModal('state-change-dialog')">Cancel</button>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -4,13 +4,15 @@
       <nav class="breadcrumb mb-2" aria-label="breadcrumbs">
         <ul>
           <li *ngIf="from=='south'">
-            <a [routerLink]="['/flow/editor/south']">South</a>
+            <a *ngIf="source" [routerLink]="['/flow/editor/south']">South</a>
+            <span *ngIf="!source">South</span>
           </li>
           <li *ngIf="from=='north'">
-            <a [routerLink]="['/flow/editor/north']">North</a>
+            <a *ngIf="source" [routerLink]="['/flow/editor/north']">North</a>
+            <span *ngIf="!source">North</span>
           </li>
-          <li *ngIf="from=='notifications'" class="pt-2">
-            <a [routerLink]="['/flow/editor/notifications']">Notifications</a>
+          <li *ngIf="from=='notifications'">
+            <span>Notifications</span>
           </li>
           <li [ngClass]="{'is-active' : !source || !isAddFilterWizard}" *ngIf="source">
             <a [routerLink]="['/flow/editor', from, source, 'details']">
@@ -31,8 +33,8 @@
       </ng-container>
     </div>
     <div *ngIf="serviceInfo.isEnabled && serviceInfo.isInstalled && from === 'notifications'">
-      <app-service-config (serviceConfigureModal)="openServiceConfigureModal()"></app-service-config>
-      <span class="icon is-small tooltip is-pulled-right is-hovered help-pad" data-tooltip="Help"
+      <app-service-config (serviceConfigureModal)="openServiceConfigureModal()" [from]="'flow-editor'"></app-service-config>
+      <span class="icon is-small tooltip has-tooltip-left has-tooltip-arrow is-pulled-right is-hovered pb-3 text-btn help-icon" data-tooltip="Help"
         (click)="goToLink('using-the-notification-service')">
         <i class="far fa-question-circle"></i>
       </span>

--- a/src/app/components/common/node-editor/node-editor.component.html
+++ b/src/app/components/common/node-editor/node-editor.component.html
@@ -26,7 +26,7 @@
           </li>
         </ul>
       </nav>
-      <ng-container *ngIf="source && !isAddFilterWizard || from === 'notifications'">
+      <ng-container *ngIf="!isAddFilterWizard">
         <button type="button" (click)="reload()" class="button is-small" title="Reload" id="refresh-check">
           <i class="fa fa-sm fa-sync" aria-hidden="true"></i>
         </button>

--- a/src/app/components/common/node-editor/node-editor.component.ts
+++ b/src/app/components/common/node-editor/node-editor.component.ts
@@ -971,8 +971,8 @@ export class NodeEditorComponent implements OnInit {
   }
 
   reload() {
-    if (this.from === 'notifications') {
-      this.router.navigate(['/flow/editor/notifications']);
+    if (!this.source) {
+      this.router.navigate(['/flow/editor', this.from]);
       return;
     }
     this.router.navigate(['/flow/editor', this.from, this.source, 'details']);

--- a/src/app/components/common/node-editor/nodes/add-notification.ts
+++ b/src/app/components/common/node-editor/nodes/add-notification.ts
@@ -1,7 +1,7 @@
 import { ClassicPreset } from "rete";
 
 export class AddNotification extends ClassicPreset.Node {
-  height = 110;
+  height = 100;
   width = 198;
   parent?: string;
 

--- a/src/app/components/core/logs/notification-log/notification-log.component.css
+++ b/src/app/components/core/logs/notification-log/notification-log.component.css
@@ -55,3 +55,7 @@
   font-size: 0.95rem;
   margin-bottom: 0.25rem !important;
 }
+
+.quickview-label {
+  font-weight: 400 !important;
+}

--- a/src/app/components/core/logs/notification-log/notification-log.component.html
+++ b/src/app/components/core/logs/notification-log/notification-log.component.html
@@ -10,7 +10,7 @@
         </ul>
       </nav>
       <div *ngIf="refreshInterval !== -1" class="fix-pad auto-refresh">
-        <label class="checkbox">
+        <label class="checkbox" [ngClass]="{'quickview-label': sourceName}">
           <input class="checkmark" type="checkbox" [checked]='isAlive' (click)="toggleAutoRefresh($event)">
           Auto Refresh
         </label>

--- a/src/app/components/core/logs/system-log/system-log.component.css
+++ b/src/app/components/core/logs/system-log/system-log.component.css
@@ -76,3 +76,7 @@
   font-size: 0.95rem;
   margin-bottom: 0.25rem !important;
 }
+
+.quickview-label {
+  font-weight: 400 !important;
+}

--- a/src/app/components/core/logs/system-log/system-log.component.html
+++ b/src/app/components/core/logs/system-log/system-log.component.html
@@ -10,7 +10,7 @@
         </ul>
       </nav>
       <div *ngIf="refreshInterval !== -1 && page === 1" class="fix-pad auto-refresh">
-        <label class="checkbox">
+        <label class="checkbox" [ngClass]="{'quickview-label': sourceName}">
           <input class="checkmark" type="checkbox" [checked]='isAlive' (click)="toggleAutoRefresh($event.target.checked)">
           Auto Refresh
         </label>

--- a/src/app/components/core/notifications/service-config/service-config.component.html
+++ b/src/app/components/core/notifications/service-config/service-config.component.html
@@ -1,5 +1,5 @@
 <a *ngIf="rolesService.hasControlAccess()" class="button" (click)="openConfigureModal()" id="config-icon">
-    <span class="icon">
-        <i class="bi bi-gear-wide-connected bi-sm" aria-hidden="true" title="Notification Service Configuration"></i>
+    <span class="icon tooltip has-tooltip-arrow has-tooltip-left" data-tooltip="Notification Service Configuration" [ngClass]="{'pb-3': from === 'flow-editor'}" >
+        <i class="bi bi-gear-wide-connected bi-sm" aria-hidden="true"></i>
     </span>
 </a>

--- a/src/app/components/core/notifications/service-config/service-config.component.ts
+++ b/src/app/components/core/notifications/service-config/service-config.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
 import { RolesService } from '../../../../services';
 
 @Component({
@@ -8,6 +8,7 @@ import { RolesService } from '../../../../services';
 })
 export class ServiceConfigComponent implements OnInit {
     @Output() serviceConfigureModal = new EventEmitter<boolean>();
+    @Input() from: string;
 
     constructor(
         public rolesService: RolesService) {}


### PR DESCRIPTION
- [x] `Add` node should be 2px dotted not dashed (On North, South and Notification pages)
- [x] Make Auto Refresh label font-size 400 in the quickview (On North, South and Notification pages)
- [x] Current page title should not be clickable in the breadcrumb (On North, South and Notification pages)
- [x] Fix gap above Notification breadcrumb
- [x] Make both icons on the Notification breadcrumb of same size
- [x] In the breadcrumb, one icon has title and another has tooltip, it should be same
- [x] Alignment issue of notify plugin name
- [x] Add reload icon on North, South and Notification pages
- [x] Changes to show long notification name in the node