### PR TITLE
FOGL-9694 Restrict service choice for control pipelines to either north

### DIFF
--- a/src/app/components/core/control-dispatcher/pipelines/add-pipeline/add-control-pipeline.component.ts
+++ b/src/app/components/core/control-dispatcher/pipelines/add-pipeline/add-control-pipeline.component.ts
@@ -434,9 +434,11 @@ export class AddControlPipelineComponent implements OnInit {
           const SortedSouthboundSvc = southboundSvc.sort((a, b) => a.name.localeCompare(b.name));
           const SortedNorthboundSvc = northboundSvc.sort((a, b) => a.name.localeCompare(b.name));
           if (direction === 'source') {
-            this.sourceNameList = SortedSouthboundSvc.concat(SortedNorthboundSvc);
+	    /** The source of a control pipeline can only be north services and not south */
+            this.sourceNameList = SortedNorthboundSvc;
           } else {
-            this.destinationNameList = SortedSouthboundSvc.concat(SortedNorthboundSvc);
+	    /** The destiantion of a control pipeline can only be south services and not north */
+            this.destinationNameList = SortedSouthboundSvc;
           }
         },
         error => {


### PR DESCRIPTION
or south as appropriate

<!-- Thank you for your contribution! -->

## What do these changes do?

Pick lists for source and destinations are now restricted to the relevant sort or north services based on the context, i.e. sort for destinations and north for sources


## Are there changes in behavior for the user?

The user is prevented from making an invalid selection

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] Code is well written w.r.t. best practices and proper comments
- [ ] Unit tests for the changes exist
- [ ] e2e tests for the changes exist
- [ ] Documentation reflects the changes including changelog
- [ ] Build works with nginx-light deployment
- [ ] Build works with Docker, if any change on docker related config files


