### PR TITLE
Show Applications text in the middle of hr; and remove extra hr if fi…

### DIFF
--- a/e2e/po/app.filters.ts
+++ b/e2e/po/app.filters.ts
@@ -7,7 +7,7 @@ export class Filters {
    * open filter wizard
    */
   openFilterWizard() {
-    return cy.get('.add-application a').click()
+    return cy.get('.opacity-07 a').click()
   }
 
   /**

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.css
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.css
@@ -10,6 +10,7 @@
   .modal-card {
     width: 80%;
   }
+
   .field-body {
     flex-grow: 2 !important;
   }
@@ -58,10 +59,6 @@ a {
   opacity: 0.8;
 }
 
-.add-application {
-  opacity: 0.7;
-}
-
 @media screen and (min-width: 769px) {
   .margin-bottom {
     margin-bottom: -0.75rem;
@@ -107,7 +104,7 @@ a {
   margin-top: 0.35rem !important;
 }
 
-.service-info-text{
+.service-info-text {
   flex-grow: 1.6;
 }
 

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.css
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.css
@@ -119,6 +119,30 @@ hr {
   margin: 0.75rem 0;
 }
 
+.hr-container {
+  position: relative;
+  margin: 1.5rem 0;
+}
+
+.hr-container .hr-text {
+  border: none;
+  height: 1px;
+  background: #dbdbdb;
+  margin: 0;
+}
+
+.hr-container .hr-text-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  padding: 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .btn-container {
   min-height: 36px;
 }

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.css
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.css
@@ -123,9 +123,8 @@ hr {
 
 .hr-container .hr-text {
   border: none;
-  height: 1px;
-  background: #dbdbdb;
   margin: 0;
+  opacity: 0.5;
 }
 
 .hr-container .hr-text-content {

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -83,6 +83,7 @@
           </div>
           <div class="hr-container">
             <hr class="hr-text">
+            <!-- this should vainsh on ends-->
             <div class="hr-text-content">
               <span class="label is-size-6 add-application" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
                 <a (click)="openAddFilterModal(true)">Applications

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -92,14 +92,14 @@
                 </a>
               </span>
               <ng-template #staticLabel>
-                <span class="label is-size-6">Applications</span>
+                <span class="label is-size-6 add-application">Applications</span>
               </ng-template>
             </div>
           </div>
           <app-filter-list #filtersListComponent [service]="task?.name" [filterPipeline]="filterPipeline"
             [from]="'filter'" (formStatus)="filterFormStatus($event)"></app-filter-list>
           <div *ngIf="!filterPipeline || filterPipeline.length === 0">
-            <p class="has-text-centered has-text-grey-light is-size-7 my-2">No filters configured</p>
+            <p class="has-text-centered has-text-grey-light is-size-7 mt-1 mb-2">No filters configured</p>
             <hr class="hr-text">
           </div>
           <div class="columns margin-bottom">

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -81,9 +81,9 @@
               </form>
             </div>
           </div>
-          <hr class="hr-text">
-          <div class="columns">
-            <div class="column has-text-centered">
+          <div class="hr-container">
+            <hr class="hr-text">
+            <div class="hr-text-content">
               <span class="label is-size-6 add-application" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
                 <a (click)="openAddFilterModal(true)">Applications
                   <span class="icon has-tooltip-right has-tooltip-arrow tooltip" data-tooltip="Add Filters">
@@ -98,7 +98,10 @@
           </div>
           <app-filter-list #filtersListComponent [service]="task?.name" [filterPipeline]="filterPipeline"
             [from]="'filter'" (formStatus)="filterFormStatus($event)"></app-filter-list>
-          <hr *ngIf="rolesService.hasEditPermissions()" class="hr-text">
+          <div *ngIf="!filterPipeline || filterPipeline.length === 0">
+            <p class="has-text-centered has-text-grey-light is-size-7 my-2">No filters configured</p>
+            <hr class="hr-text">
+          </div>
           <div class="columns margin-bottom">
             <div class="column is-9">
               <!-- Note: task here is old variable name retained; if processName is north_C task represents a Northbound service -->

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -83,9 +83,8 @@
           </div>
           <div class="hr-container">
             <hr class="hr-text">
-            <!-- this should vainsh on ends-->
             <div class="hr-text-content">
-              <span class="label is-size-6 add-application" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
+              <span class="label is-size-6 opacity-07" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
                 <a (click)="openAddFilterModal(true)">Applications
                   <span class="icon has-tooltip-right has-tooltip-arrow tooltip" data-tooltip="Add Filters">
                     <i class="bi bi-plus-circle plus-icon bi-md" aria-hidden="true"></i>
@@ -93,7 +92,7 @@
                 </a>
               </span>
               <ng-template #staticLabel>
-                <span class="label is-size-6 add-application">Applications</span>
+                <span class="label is-size-6 opacity-07">Applications</span>
               </ng-template>
             </div>
           </div>

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -84,6 +84,30 @@ hr {
   margin: 0.75rem 0;
 }
 
+.hr-container {
+  position: relative;
+  margin: 1.5rem 0;
+}
+
+.hr-container .hr-text {
+  border: none;
+  height: 1px;
+  background: #dbdbdb;
+  margin: 0;
+}
+
+.hr-container .hr-text-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  padding: 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .btn-container {
   min-height: 36px;
 }

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -92,8 +92,9 @@ hr {
 .hr-container .hr-text {
   border: none;
   height: 1px;
-  background: #dbdbdb;
+  background: lightgray;
   margin: 0;
+  opacity: 0.6;
 }
 
 .hr-container .hr-text-content {

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -88,10 +88,8 @@ hr {
 
 .hr-container .hr-text {
   border: none;
-  height: 1px;
-  background: lightgray;
   margin: 0;
-  opacity: 0.6;
+  opacity: 0.5;
 }
 
 .hr-container .hr-text-content {

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -14,6 +14,7 @@
   .modal-card {
     width: 80%;
   }
+
   .field-body {
     flex-grow: 2 !important;
   }
@@ -27,10 +28,6 @@ a {
   .margin-bottom {
     margin-bottom: -0.75rem;
   }
-}
-
-.add-application {
-  opacity: 0.7;
 }
 
 .help-icon {
@@ -65,14 +62,14 @@ a {
   margin-top: 0.35rem !important;
 }
 
-.flow-editor{
+.flow-editor {
   background: none;
   border: none;
   font-size: 14px;
   margin-right: 15px;
 }
 
-.service-info-text{
+.service-info-text {
   flex-grow: 1.6;
 }
 

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -37,6 +37,7 @@
           </div>
           <div class="hr-container">
             <hr class="hr-text">
+            <!-- this should vainsh on ends-->
             <div class="hr-text-content">
               <span class="label is-size-6 add-application" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
                 <a (click)="openAddFilterModal(true)">Applications

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -35,9 +35,9 @@
               </div>
             </div>
           </div>
-          <hr class="hr-text">
-          <div class="columns">
-            <div class="column has-text-centered">
+          <div class="hr-container">
+            <hr class="hr-text">
+            <div class="hr-text-content">
               <span class="label is-size-6 add-application" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
                 <a (click)="openAddFilterModal(true)">Applications
                   <span class="icon has-tooltip-right has-tooltip-arrow tooltip" data-tooltip="Add Filters">
@@ -46,13 +46,18 @@
                 </a>
               </span>
               <ng-template #staticLabel>
-                <span class="label is-size-6">Applications</span>
+                <span class="label is-size-6 add-application">Applications</span>
               </ng-template>
             </div>
           </div>
           <app-filter-list #filtersListComponent [service]="service?.name" [filterPipeline]="filterPipeline"
             [from]="'filter'" (formStatus)="filterFormStatus($event)"></app-filter-list>
-          <hr class="hr-text">
+          
+          <div *ngIf="!filterPipeline || filterPipeline.length === 0">
+            <p class="has-text-centered has-text-grey-light is-size-7 my-2">No filters configured</p>
+            <hr class="hr-text">
+          </div>
+         
           <div class="columns margin-bottom">
             <ng-container *ngIf="service != undefined">
               <div class="column is-9">

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -37,9 +37,8 @@
           </div>
           <div class="hr-container">
             <hr class="hr-text">
-            <!-- this should vainsh on ends-->
             <div class="hr-text-content">
-              <span class="label is-size-6 add-application" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
+              <span class="label is-size-6 opacity-07" *ngIf="rolesService.hasEditPermissions(); else staticLabel">
                 <a (click)="openAddFilterModal(true)">Applications
                   <span class="icon has-tooltip-right has-tooltip-arrow tooltip" data-tooltip="Add Filters">
                     <i class="bi bi-md bi-plus-circle plus-icon" aria-hidden="true"></i>
@@ -47,18 +46,18 @@
                 </a>
               </span>
               <ng-template #staticLabel>
-                <span class="label is-size-6 add-application">Applications</span>
+                <span class="label is-size-6 opacity-07">Applications</span>
               </ng-template>
             </div>
           </div>
           <app-filter-list #filtersListComponent [service]="service?.name" [filterPipeline]="filterPipeline"
             [from]="'filter'" (formStatus)="filterFormStatus($event)"></app-filter-list>
-          
+
           <div *ngIf="!filterPipeline || filterPipeline.length === 0">
             <p class="has-text-centered has-text-grey-light is-size-7 mt-1 mb-2">No filters configured</p>
             <hr class="hr-text">
           </div>
-         
+
           <div class="columns margin-bottom">
             <ng-container *ngIf="service != undefined">
               <div class="column is-9">

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -54,7 +54,7 @@
             [from]="'filter'" (formStatus)="filterFormStatus($event)"></app-filter-list>
           
           <div *ngIf="!filterPipeline || filterPipeline.length === 0">
-            <p class="has-text-centered has-text-grey-light is-size-7 my-2">No filters configured</p>
+            <p class="has-text-centered has-text-grey-light is-size-7 mt-1 mb-2">No filters configured</p>
             <hr class="hr-text">
           </div>
          

--- a/src/styles.css
+++ b/src/styles.css
@@ -375,6 +375,10 @@ span.tooltip {
   font-size: 0.75rem;
 }
 
+.opacity-07 {
+  opacity: 0.7;
+}
+
 .bi-sm,
 .text-btn,
 .steps-sm {
@@ -402,7 +406,7 @@ span.tooltip {
 }
 
 .help-pad {
-  margin: 19px 7px; /* check if this is correct, This is causing issue for header size if > 16px? */
+  margin: 19px 7px;
   font-size: 0.9rem;
 }
 
@@ -482,7 +486,8 @@ span.tooltip {
 }
 
 .hr-text {
-  background-color: #fff !important; /* this is for? */
+  background-color: #fff !important;
+  /* ensures clean white background for text overlay effect */
   line-height: 1em;
   position: relative;
   outline: 0;
@@ -510,8 +515,6 @@ span.tooltip {
   padding: 0 .5em;
   line-height: 1.5em;
   color: #818078;
-  
-  background-color: #fff; /* this is needed? */
 }
 
 .content table td {

--- a/src/styles.css
+++ b/src/styles.css
@@ -482,7 +482,7 @@ span.tooltip {
 }
 
 .hr-text {
-  background-color: #fff !important;
+  background-color: #fff !important; /* this is for? */
   line-height: 1em;
   position: relative;
   outline: 0;
@@ -510,7 +510,8 @@ span.tooltip {
   padding: 0 .5em;
   line-height: 1.5em;
   color: #818078;
-  background-color: #fff;
+  
+  background-color: #fff; /* this is needed? */
 }
 
 .content table td {

--- a/src/styles.css
+++ b/src/styles.css
@@ -489,7 +489,7 @@ span.tooltip {
   border: 0;
   color: black;
   text-align: center;
-  opacity: .5;
+  opacity: .3;
 }
 
 .hr-text:before {


### PR DESCRIPTION
…lters length > 0; Also show help text when no filters configured

<img width="1155" height="196" alt="Screenshot 2025-07-23 at 3 28 46 AM" src="https://github.com/user-attachments/assets/64050a1e-5ac7-472d-aeb4-d5131d168d8d" />

Vs

<img width="1177" height="208" alt="Screenshot 2025-07-23 at 3 28 53 AM" src="https://github.com/user-attachments/assets/b5bf3e79-ced7-4b25-8713-ecb7bbd99267" />


Also when filter is there, no extra line following the box line

<img width="1171" height="233" alt="Screenshot 2025-07-23 at 3 29 06 AM" src="https://github.com/user-attachments/assets/de670372-afcf-4151-8a45-0c61c534251e" />


