### PR TITLE
FOGL-8859 (b): Fixes for missing Bulma upgrade CSS fixes on different pages

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -95,8 +95,8 @@ Set API base URL in `environments/environment.prod.ts`, You can always change it
 | Library         | Version | Latest Stable (? Y/n) | License |
 | --------------- | ------- | --------------------- | ------- |
 | Angular         | 16.2.12 | 20.1.0                | MIT     |
-| Angular CLI     | 16.2.12 | 20.1.0                | MIT     |
-| Bulma css       | 0.9.4   | 1.0.1                 | MIT     |
+| Angular CLI     | 16.2.10 | 20.1.0                | MIT     |
+| Bulma css       | 1.0.4   | 1.0.1                 | MIT     |
 | Font-Awesome    | 6.4.0   | 6.4.0                 | MIT     |
 | Bootstrap-Icons | 1.11.1  | 1.11.3                | MIT     |
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -95,8 +95,8 @@ Set API base URL in `environments/environment.prod.ts`, You can always change it
 | Library         | Version | Latest Stable (? Y/n) | License |
 | --------------- | ------- | --------------------- | ------- |
 | Angular         | 16.2.12 | 20.1.0                | MIT     |
-| Angular CLI     | 16.2.10 | 20.1.0                | MIT     |
-| Bulma css       | 1.0.4   | 1.0.1                 | MIT     |
+| Angular CLI     | 16.2.10 | 20.2.0                | MIT     |
+| Bulma css       | 1.0.4   | 1.0.4                 | MIT     |
 | Font-Awesome    | 6.4.0   | 6.4.0                 | MIT     |
 | Bootstrap-Icons | 1.11.1  | 1.11.3                | MIT     |
 

--- a/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
+++ b/src/app/components/common/node-editor/south/asset-tracker/asset-tracker.component.html
@@ -1,44 +1,42 @@
 <div class="container is-fluid">
-    <nav class="breadcrumb readings-breadcrumb" aria-label="breadcrumbs">
-      <ul>
-        <li class="is-active"><a>{{service?.name}}</a></li>
-        <li class="is-active">
-          <a href="#" aria-current="page">Readings</a>
-        </li>
-      </ul>
-    </nav>
-    <button type="button" *ngIf="!isAlive" (click)="reload()" title="Reload" class="button is-small" id="refresh-check">
-        <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
-    </button>
-    <table class="table is-responsive mt-6 ml-2">
-      <thead>
-        <tr>
-          <th class="align-th">Asset</th>
-          <th></th>
-          <th class="align-th">Readings</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor='let data of service?.assets'>
-            <td>
-              <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
-                class="deprecate"
-                (click)="selectAsset(data?.asset)">
-                <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow"
-                  data-tooltip="Deprecate asset">
-                  <i class="bi bi-eraser"></i>
-                </span>
-              </a>
-              <span>{{data.asset}}</span>
-            </td>
-            <td>
-            </td>
-            <td class="readings-count">
-              <span class="level-right">{{data.count | number}}</span>
-            </td>
-        </tr>
-      </tbody>
-    </table>
-    <button [appDisableUntilResponse]="reenableButton"
-      class="button is-small is-ghost" (click)="exportReadings()">Export Readings</button>
-  </div>
+  <nav class="breadcrumb readings-breadcrumb" aria-label="breadcrumbs">
+    <ul>
+      <li class="is-active"><a>{{service?.name}}</a></li>
+      <li class="is-active">
+        <a href="#" aria-current="page">Readings</a>
+      </li>
+    </ul>
+  </nav>
+  <button type="button" *ngIf="!isAlive" (click)="reload()" title="Reload" class="button is-small" id="refresh-check">
+    <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
+  </button>
+  <table class="table is-responsive mt-6 ml-2">
+    <thead>
+      <tr>
+        <th class="align-th">Asset</th>
+        <th></th>
+        <th class="align-th">Readings</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor='let data of service?.assets'>
+        <td>
+          <a *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()"
+            class="deprecate" (click)="selectAsset(data?.asset)">
+            <span class="icon is-small tooltip has-tooltip-right has-tooltip-arrow" data-tooltip="Deprecate asset">
+              <i class="bi bi-eraser"></i>
+            </span>
+          </a>
+          <span>{{data.asset}}</span>
+        </td>
+        <td>
+        </td>
+        <td class="readings-count">
+          <span class="level-right">{{data.count | number}}</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <button [appDisableUntilResponse]="reenableButton" class="button is-small is-ghost" (click)="exportReadings()">Export
+    Readings</button>
+</div>

--- a/src/app/components/common/time-dropdown/time-dropdown.component.html
+++ b/src/app/components/common/time-dropdown/time-dropdown.component.html
@@ -8,8 +8,8 @@
       <button class="button is-small small-btn has-background-white-ter unit-button" aria-haspopup="true"
         aria-controls="dropdown-menu" (click)=toggleDropdown()>
         <span>{{selectedUnit}}</span>
-        <span class="icon is-small">
-          <i class="fa fa-sm fa-angle-down" aria-hidden="true"></i>
+        <span class="icon is-small m-0">
+          <i class="fa fa-xs fa-angle-down" aria-hidden="true"></i>
         </span>
       </button>
     </div>

--- a/src/app/components/core/asset-readings/assets/assets.component.html
+++ b/src/app/components/core/asset-readings/assets/assets.component.html
@@ -8,7 +8,7 @@
       <span *ngIf="!isAlive"
         class="icon is-small is-pulled-right is-hovered assets-control has-tooltip-left has-tooltip-arrow tooltip"
         data-tooltip="Reload" (click)="getAsset()">
-        <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+        <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
       </span>
       <ng-container *ngIf="developerFeaturesService.getDeveloperFeatureControl() && rolesService.hasEditPermissions()">
         <span *ngIf="assets?.length > 0"

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -8,7 +8,7 @@
             {{assetCode}}
           </span>
           <button *ngIf="!isAlive" (click)="refresh()" title="Reload" class="button small-btn" id="refresh-check">
-            <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+            <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
           </button>
         </div>
         <ng-container

--- a/src/app/components/core/backup-restore/backup-restore.component.html
+++ b/src/app/components/core/backup-restore/backup-restore.component.html
@@ -4,7 +4,7 @@
       <p class="card-header-title">
         Backups
         <button *ngIf="!isAlive" (click)="getBackup()" title="Reload" class="button is-small" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </p>
       <div>

--- a/src/app/components/core/certificate/certificate-store/certificate-store.component.html
+++ b/src/app/components/core/certificate/certificate-store/certificate-store.component.html
@@ -4,7 +4,7 @@
       <p class="card-header-title">
         Certificate Store &nbsp;
         <button (click)="getCertificates()" title="Reload" class="button is-small" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </p>
       <div *ngIf="rolesService.hasEditPermissions()">

--- a/src/app/components/core/configuration-manager/configuration-manager.component.html
+++ b/src/app/components/core/configuration-manager/configuration-manager.component.html
@@ -12,7 +12,7 @@
             <div class="column">
               <button class="button is-small category-tree" id="refresh-tree" (click)="getTreeStructure()">
                 <span class="icon is-small">
-                  <i class="bi bi-lg bi-arrow-repeat" title="Reload"></i>
+                  <i class="bi bi-md bi-arrow-repeat" title="Reload"></i>
                 </span>
               </button>
             </div>
@@ -31,7 +31,7 @@
                     <button class="button is-small" id="refresh-check"
                       (click)="refreshCategory(category.name, category.description)">
                       <span class="icon is-small">
-                        <i class="bi bi-lg bi-arrow-repeat" title="Reload"></i>
+                        <i class="bi bi-md bi-arrow-repeat" title="Reload"></i>
                       </span>
                     </button>
                   </p>

--- a/src/app/components/core/control-dispatcher/add-control-acl/add-control-acl.component.html
+++ b/src/app/components/core/control-dispatcher/add-control-acl/add-control-acl.component.html
@@ -11,7 +11,7 @@
       </ul>
     </nav>
     <button *ngIf="editMode" (click)="refresh()" class="button is-small" id="refresh-check" title="Reload">
-      <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+      <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
     </button>
   </div>
   <div class="card">

--- a/src/app/components/core/control-dispatcher/add-control-script/add-control-script.component.html
+++ b/src/app/components/core/control-dispatcher/add-control-script/add-control-script.component.html
@@ -11,7 +11,7 @@
       </ul>
     </nav>
     <button *ngIf="editMode" (click)="refresh()" class="button is-small" title="Reload" id="refresh-check">
-      <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+      <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
     </button>
   </div>
   <div class="card">

--- a/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.html
+++ b/src/app/components/core/control-dispatcher/api-flow/add-edit-api-flow/add-edit-api-flow.component.html
@@ -13,7 +13,7 @@
     <nav>
       <button type="button" *ngIf="editMode" (click)="getAPIFlow()" class="button is-small" title="Reload"
         id="refresh-check">
-        <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+        <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
       </button>
     </nav>
   </div>

--- a/src/app/components/core/control-dispatcher/api-flow/api-flow.component.html
+++ b/src/app/components/core/control-dispatcher/api-flow/api-flow.component.html
@@ -6,7 +6,7 @@
             <div id="control-api-flow" class="card-header-title">
                 Control API Entry Points
                 <button class="button is-small" id="refresh-check" title="Reload" (click)="getAPIFlows()">
-                    <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+                    <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
                 </button>
             </div>
             <a *ngIf="rolesService.hasControlAccess()" class="button is-small is-light"

--- a/src/app/components/core/control-dispatcher/control-schedule-task/control-schedule-task-details.component.html
+++ b/src/app/components/core/control-dispatcher/control-schedule-task/control-schedule-task-details.component.html
@@ -11,7 +11,7 @@
       </ul>
     </nav>
     <button *ngIf="editMode" (click)="refresh()" title="Reload" class="button is-small" id="refresh-check">
-      <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+      <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
     </button>
   </div>
   <div class="card">

--- a/src/app/components/core/control-dispatcher/list-control-dispatcher/acl-list/acl-list.component.html
+++ b/src/app/components/core/control-dispatcher/list-control-dispatcher/acl-list/acl-list.component.html
@@ -6,7 +6,7 @@
       <div id="control-acl" class="card-header-title">
         Control ACLs
         <button class="button is-small" id="refresh-check" title="Reload" (click)="getACLs()">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <a *ngIf="sharedService.checkAuth()" class="button is-small is-light" routerLink="add">
@@ -55,7 +55,7 @@
         </tr>
         <tr>
           <td>
-            <a [routerLink]="['/control-dispatcher/acl', acl?.name, 'details']" class="button is-ghost is-text p-0">
+            <a [routerLink]="['/control-dispatcher/acl', acl?.name, 'details']" class="button is-ghost p-0">
               {{acl?.name}}
             </a>
           </td>

--- a/src/app/components/core/control-dispatcher/list-control-dispatcher/control-scripts-list/control-scripts-list.component.html
+++ b/src/app/components/core/control-dispatcher/list-control-dispatcher/control-scripts-list/control-scripts-list.component.html
@@ -6,7 +6,7 @@
       <div id="control-acl" class="card-header-title">
         Control Scripts
         <button class="button is-small" id="refresh-check" title="Reload" (click)="getControlScripts()">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <a *ngIf="rolesService.hasControlAccess()" class="button is-small is-light" routerLink="add">

--- a/src/app/components/core/control-dispatcher/pipelines/add-pipeline/add-control-pipeline.component.html
+++ b/src/app/components/core/control-dispatcher/pipelines/add-pipeline/add-control-pipeline.component.html
@@ -12,7 +12,7 @@
     </nav>
     <button type="button" *ngIf="editMode" (click)="refresh()" class="button is-small" title="Reload"
       id="refresh-check">
-      <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+      <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
     </button>
   </div>
   <ng-container *ngIf="unsavedChangesInFilterForm">

--- a/src/app/components/core/control-dispatcher/pipelines/control-pipelines.component.html
+++ b/src/app/components/core/control-dispatcher/pipelines/control-pipelines.component.html
@@ -6,7 +6,7 @@
       <div class="card-header-title">
         Control Pipelines
         <button class="button is-small" id="refresh-check" title="Reload" (click)="getControlPipelines()">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <a *ngIf="rolesService?.hasControlAccess()" class="button is-small is-light" (click)="addControlPipeline()">

--- a/src/app/components/core/developer/additional-services/additional-service-modal/additional-service-modal.component.html
+++ b/src/app/components/core/developer/additional-services/additional-service-modal/additional-service-modal.component.html
@@ -4,7 +4,7 @@
     <header class="modal-card-head">
       <span *ngIf="serviceInfo.added" class="modal-card-title is-size-6">{{serviceName}}
         <button class="button is-small" id="refresh-check" title="Reload" (click)="refreshService(true)">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
         <p class="help has-text-grey modal-subtitle mt-0">{{serviceInfo.type !== 'BucketStorage' ? serviceInfo.type :
           'Bucket Storage'}} Service</p>

--- a/src/app/components/core/developer/additional-services/list-additional-services.component.html
+++ b/src/app/components/core/developer/additional-services/list-additional-services.component.html
@@ -13,7 +13,7 @@
       </nav>
       <button class="button is-small" id="refresh-check" title="Reload"
         (click)="additionalServicesUtils.getAllServiceStatus(false, 'additional-services')">
-        <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+        <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
       </button>
     </div>
   </div>

--- a/src/app/components/core/developer/packages/list-python-packages/list-python-packages.component.html
+++ b/src/app/components/core/developer/packages/list-python-packages/list-python-packages.component.html
@@ -12,7 +12,7 @@
         </ul>
       </nav>
       <button (click)="getPythonPackages()" class="button is-small" title="Reload" id="refresh-check">
-        <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+        <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
       </button>
     </div>
     <a *ngIf="rolesService?.hasEditPermissions()" class="button is-small"

--- a/src/app/components/core/developer/perfmon/list/table.component.html
+++ b/src/app/components/core/developer/perfmon/list/table.component.html
@@ -9,7 +9,7 @@
           </a>
         </li>
         <button (click)="getMonitors()" class="button is-small" title="Reload" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </ul>
     </nav>

--- a/src/app/components/core/logs/audit-log/audit-log.component.html
+++ b/src/app/components/core/logs/audit-log/audit-log.component.html
@@ -4,7 +4,7 @@
       <div class="card-header-title">
         <span>Audit Logs</span>
         <button *ngIf="!isAlive" (click)="getAuditLogs()" class="button is-small" title="Reload" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <div *ngIf="refreshInterval !== -1" class="fix-pad auto-refresh">

--- a/src/app/components/core/logs/notification-log/notification-log.component.html
+++ b/src/app/components/core/logs/notification-log/notification-log.component.html
@@ -24,7 +24,7 @@
           <span>Notification Logs</span>
           <button *ngIf="!isAlive" title="Reload" (click)="getNotificationLogs()" class="button is-small"
             id="refresh-check">
-            <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+            <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
           </button>
         </div>
         <div *ngIf="refreshInterval !== -1" class="fix-pad auto-refresh">

--- a/src/app/components/core/logs/packages-log/packages-log.component.html
+++ b/src/app/components/core/logs/packages-log/packages-log.component.html
@@ -4,7 +4,7 @@
       <div class="card-header-title">
         <span>Package Logs</span>
         <button *ngIf="!isAlive" title="Reload" (click)="getPackagesLog()" class="button is-small" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <div *ngIf="refreshInterval !== -1" class="fix-pad auto-refresh">

--- a/src/app/components/core/logs/system-log/system-log.component.html
+++ b/src/app/components/core/logs/system-log/system-log.component.html
@@ -24,7 +24,7 @@
         <div class="card-header-title">
           <span>System Logs</span>
           <a *ngIf="!isAlive || page > 1" (click)="onFirst()" title="Reload" class="button is-small" id="refresh-check">
-            <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+            <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
           </a>
         </div>
         <div *ngIf="refreshInterval !== -1 && page === 1" class="fix-pad auto-refresh">

--- a/src/app/components/core/logs/tasks/tasks.component.html
+++ b/src/app/components/core/logs/tasks/tasks.component.html
@@ -4,7 +4,7 @@
       <div class="card-header-title">
         <span>Tasks</span>
         <button *ngIf="!isAlive" (click)="getLatestTasks()" title="Reload" class="button is-small" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <div *ngIf="refreshInterval !== -1" class="fix-pad auto-refresh">

--- a/src/app/components/core/north/north.component.css
+++ b/src/app/components/core/north/north.component.css
@@ -1,8 +1,3 @@
 table tr td {
     vertical-align: middle;
 }
-
-.is-text {
-    padding-left: 0;
-    padding-right: 0;
-}

--- a/src/app/components/core/north/north.component.html
+++ b/src/app/components/core/north/north.component.html
@@ -5,7 +5,7 @@
         North Instances
         <button *ngIf="!isAlive" (click)="getNorthTasks(true)" class="button is-small" title="Reload"
           id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <a *ngIf="rolesService?.hasEditPermissions()" id="add_task" class="button is-small is-light mr-2"
@@ -50,7 +50,7 @@
                     </div>
                   </td>
                   <td class="align-content">
-                    <a class="button is-ghost is-text py-0" (click)="openNorthTaskModal(t)">{{t.name}}</a>
+                    <a class="button is-ghost p-0" (click)="openNorthTaskModal(t)">{{t.name}}</a>
                   </td>
                   <td class="align-content">
                     <span *ngIf="t?.processName === 'north_C'" class="tag is-light is-rounded">Service</span>

--- a/src/app/components/core/north/task-schedule/task-schedule.component.css
+++ b/src/app/components/core/north/task-schedule/task-schedule.component.css
@@ -1,6 +1,4 @@
 .breadcrumb {
-  padding-top: 0.85rem;
-  margin-top: 10px;
-  font-size: 0.95rem;
-  margin-bottom: 0.25rem !important;
+  margin-top: 14px;
+  margin-bottom: 14px !important;
 }

--- a/src/app/components/core/north/task-schedule/task-schedule.component.html
+++ b/src/app/components/core/north/task-schedule/task-schedule.component.html
@@ -1,10 +1,11 @@
 <div class="container is-fluid">
-  <nav aria-label="breadcrumbs" class="breadcrumb">
+  <nav aria-label="breadcrumbs" class="breadcrumb has-text-weight-medium">
     <ul>
       <li class="is-active"><a>{{taskSchedule.name}}</a></li>
       <li class="is-active"><a href="#" aria-current="page">Task Schedule</a></li>
     </ul>
   </nav>
+  <hr class="my-0">
   <div class="section px-0 py-5">
     <div class="columns">
       <div class="column">
@@ -59,9 +60,6 @@
           </div>
 
           <div class="field is-horizontal">
-            <div class="field-label">
-              <!-- Left empty for spacing -->
-            </div>
             <div class="field-body">
               <div class="field">
                 <div class="control">

--- a/src/app/components/core/notifications/notifications.component.css
+++ b/src/app/components/core/notifications/notifications.component.css
@@ -9,11 +9,6 @@
   right: 0;
 }
 
-.is-text {
-  padding-left: 0;
-  padding-right: 0;
-}
-
 .custom-pad {
   margin-top: 6px;
 }

--- a/src/app/components/core/notifications/notifications.component.html
+++ b/src/app/components/core/notifications/notifications.component.html
@@ -8,7 +8,7 @@
           Notifications
           <a class="button is-small" (click)="getNotificationInstance()" title="Reload" id="refresh-check">
             <span class="icon is-small">
-              <i class="bi bi-lg bi-arrow-repeat"></i>
+              <i class="bi bi-md bi-arrow-repeat"></i>
             </span>
           </a>
         </p>
@@ -55,7 +55,7 @@
               <tbody>
                 <tr *ngFor="let instance of notificationInstances" [ngClass]="{'fade': (instance.enable == 'false')}">
                   <td class="align-content">
-                    <a class="button is-ghost is-text py-0"
+                    <a class="button is-ghost p-0"
                       (click)="openNotificationInstanceModal(instance)">{{instance.name}}</a>
                   </td>
                   <td class="align-content">

--- a/src/app/components/core/notifications/service-warning/service-warning.component.html
+++ b/src/app/components/core/notifications/service-warning/service-warning.component.html
@@ -11,7 +11,7 @@
                 (click)="openConfigureModal()"><strong>Configure</strong></a>
             <button (click)="refreshServiceInfo()" class="button is-small" id="refresh-check">
                 <span class="icon">
-                    <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true" title="Recheck"></i>
+                    <i class="bi bi-md bi-arrow-repeat" aria-hidden="true" title="Recheck"></i>
                 </span>
             </button>
         </div>

--- a/src/app/components/core/scheduler/list-schedules/list-schedules.component.html
+++ b/src/app/components/core/scheduler/list-schedules/list-schedules.component.html
@@ -4,7 +4,7 @@
       <p id="scheduled-process" class="card-header-title">
         Schedules &nbsp;
         <button (click)="getSchedules()" class="button is-small" title="Reload" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </p>
     </header>

--- a/src/app/components/core/south/south.component.css
+++ b/src/app/components/core/south/south.component.css
@@ -10,11 +10,6 @@
   padding-top: 0.8em;
 }
 
-.is-text {
-  padding-left: 0;
-  padding-right: 0;
-}
-
 .align-right {
   text-align: right;
 }

--- a/src/app/components/core/south/south.component.html
+++ b/src/app/components/core/south/south.component.html
@@ -5,7 +5,7 @@
         South Services
         <button *ngIf="!isAlive" (click)="getSouthboundServices(true)" title="Reload" class="button is-small"
           id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </div>
       <a *ngIf="rolesService?.hasEditPermissions()" id="add_south_service" class="button is-small is-light mr-2"
@@ -61,7 +61,7 @@
                   </td>
                   <td class="align-content">
                     <div class="is-flex is-align-items-center">
-                      <a class="button is-ghost is-text" (click)="openSouthServiceModal(svc)">{{svc.name}}</a>
+                      <a class="button is-ghost px-0" (click)="openSouthServiceModal(svc)">{{svc.name}}</a>
                     </div>
                   </td>
                   <td class="align-content content-pad">

--- a/src/app/components/core/support/support.component.html
+++ b/src/app/components/core/support/support.component.html
@@ -4,7 +4,7 @@
       <p class="card-header-title">
         Support Bundles &nbsp;
         <button (click)="getBundles()" title="Reload" class="button is-small" id="refresh-check">
-          <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+          <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
         </button>
       </p>
       <div *ngIf="rolesService.hasEditPermissions()">

--- a/src/app/components/core/system-alert/system-alert.component.html
+++ b/src/app/components/core/system-alert/system-alert.component.html
@@ -52,7 +52,7 @@
             <p class="control">
               <button *ngIf="isManualRefresh" class="button is-small pl-1" id="refresh-alerts" (click)="getAlerts()">
                 <span class="icon is-small is-pulled-left">
-                  <i class="bi bi-lg bi-arrow-repeat" title="Reload"></i>
+                  <i class="bi bi-md bi-arrow-repeat" title="Reload"></i>
                 </span>
               </button>
               <button *ngIf="alertsCount > 1" class="button is-small pl-0 is-ghost" (click)="sortByKey === 'time' ? sortByTimestamp() : groupByUrgencySortedByTime(this.systemAlerts)">Sort by {{sortByKey}}</button>

--- a/src/app/components/core/user-management/user-management.component.html
+++ b/src/app/components/core/user-management/user-management.component.html
@@ -17,7 +17,7 @@
             <div class="is-flex columns is-vcentered m-0 p-0">
               <div *ngIf="selectedTab == 1" class="column is-narrow px-0">
                 <a type="button" (click)="getUsers()" class="button is-small" title="Reload" id="refresh-check">
-                  <i class="bi bi-lg bi-arrow-repeat" aria-hidden="true"></i>
+                  <i class="bi bi-md bi-arrow-repeat" aria-hidden="true"></i>
                 </a>
               </div>
               <div class="column is-narrow">


### PR DESCRIPTION
- [x] Reload icons in header changed from bi-lg to bi-md
- [x] In Asset & Readings, fixed caret icon for time unit dropdown
- [x] Correctly used button class="button is-ghost" on different pages and removed unwanted css class
- [x] Fixed breadcrumb and alignment in Flow editor node Task schedule pane
- [x] Updated "Core" section in `developers-guide.md` file
- [ ] Fix cross ( x ) icon on alert
- [ ] Left/Right caret icon on detail page for tab navigation